### PR TITLE
Don't enforce dot rules for quoted-string in local-part

### DIFF
--- a/mail/src/main/java/javax/mail/internet/InternetAddress.java
+++ b/mail/src/main/java/javax/mail/internet/InternetAddress.java
@@ -1319,7 +1319,11 @@ public class InternetAddress extends Address implements Cloneable {
 		    throw new AddressException(
 		     "Quoted local address contains newline without whitespace",
 			addr);
-	    } else if (c == '.') {
+	    }
+	    if (inquote)
+		continue;
+	    // dot rules should not be applied to quoted-string
+	    if (c == '.') {
 		if (i == start)
 		    throw new AddressException(
 			"Local address starts with dot", addr);
@@ -1327,8 +1331,6 @@ public class InternetAddress extends Address implements Cloneable {
 		    throw new AddressException(
 			"Local address contains dot-dot", addr);
 	    }
-	    if (inquote)
-		continue;
 	    if (c == '@') {
 		if (i == 0)
 		    throw new AddressException("Missing local name", addr);

--- a/mail/src/test/resources/javax/mail/internet/addrlist
+++ b/mail/src/test/resources/javax/mail/internet/addrlist
@@ -771,3 +771,16 @@ To: " <string@string.ru>
 Expect: 1
 	string@string.ru
 Header: false
+Strict: true
+To: ".foo"@example.com
+Expect: 1
+	".foo"@example.com
+To: "foo."@example.com
+Expect: 1
+	"foo."@example.com
+To: "foo..bar"@example.com
+Expect: 1
+	"foo..bar"@example.com
+To: "foo..bar".baz@example.com
+Expect: 1
+	"foo..bar".baz@example.com


### PR DESCRIPTION
According to RFC822, quoted-string in local-part can contain special characters even ".", so following addresses should be accepted.

"foo..bar"@example.com
"foo..bar".baz@example.com