### PR TITLE
BASE64DecoderStream#read: Avoid returning -1 (EOF) in when length is 0

### DIFF
--- a/mail/src/main/java/com/sun/mail/util/BASE64DecoderStream.java
+++ b/mail/src/main/java/com/sun/mail/util/BASE64DecoderStream.java
@@ -140,7 +140,7 @@ public class BASE64DecoderStream extends FilterInputStream {
 	}
 
 	if (off == off0)	// haven't returned any data
-	    return -1;
+	    return len == 0 ? 0 : -1;
 	else			// returned some data before hitting EOF
 	    return off - off0;
     }


### PR DESCRIPTION
Quote from the JavaDocs of InputStream

> <p> If <code>len</code> is zero, then no bytes are read and <code>0</code> is returned;

This fixes #408

Signed-off-by: david <davidscandurra@gmail.com>