### PR TITLE
NPE in MailHandler::isLoggable #421

### DIFF
--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -27,6 +27,7 @@ The following bugs have been fixed in the 1.6.5 release.
 E  398	Don't enforce dot rules for quoted-string in local-part
 E  399	NPE com.sun.mail.imap.protocol.BODY.getOrigin() since 1.6.4
 E  400	finalizecleanclose false can send commands causing unhandled exception
+E  421	NPE in MailHandler::isLoggable
 
 
 		  CHANGES IN THE 1.6.4 RELEASE


### PR DESCRIPTION
This patch aligns with changes in https://bugs.openjdk.java.net/browse/JDK-8233979.  MailHandler.isLoggable is no longer null hostile.  MailHandler.publish now guards against malicious overrides of isLoggable and will report an error to the error manager instead of throwing back to the caller.

I ditched the idea of trying to probe into the super class to determine if it is null hostile as that triggered SpotBugs warnings which were not worth trying to work around.