### PR TITLE
Do not use generated message-id if user provides one

### DIFF
--- a/mail/src/main/java/javax/mail/internet/MimeMessage.java
+++ b/mail/src/main/java/javax/mail/internet/MimeMessage.java
@@ -2207,6 +2207,7 @@ public class MimeMessage extends Message implements MimePart {
      * @since		JavaMail 1.4
      */
     protected void updateMessageID() throws MessagingException {
+    if(getHeader("Message-ID") == null)	
 	setHeader("Message-ID", 
 		  "<" + UniqueValue.getUniqueMessageIDValue(session) + ">");
           


### PR DESCRIPTION
Should be used with setHeader
addHeader still has the issue despiste this check
(https://github.com/eclipse-ee4j/mail/issues/433)