### PR TITLE
Use user provided message-id

### DIFF
--- a/mail/src/main/java/javax/mail/internet/MimeMessage.java
+++ b/mail/src/main/java/javax/mail/internet/MimeMessage.java
@@ -2207,6 +2207,7 @@ public class MimeMessage extends Message implements MimePart {
      * @since		JavaMail 1.4
      */
     protected void updateMessageID() throws MessagingException {
+    if(getHeader("Message-ID") == null)
 	setHeader("Message-ID", 
 		  "<" + UniqueValue.getUniqueMessageIDValue(session) + ">");
           

--- a/mail/src/main/java/javax/mail/internet/MimeMessage.java
+++ b/mail/src/main/java/javax/mail/internet/MimeMessage.java
@@ -2207,10 +2207,10 @@ public class MimeMessage extends Message implements MimePart {
      * @since		JavaMail 1.4
      */
     protected void updateMessageID() throws MessagingException {
-    if(getHeader("Message-ID") == null)
-	setHeader("Message-ID", 
-		  "<" + UniqueValue.getUniqueMessageIDValue(session) + ">");
-          
+    if(getHeader("Message-ID") == null) {
+    	setHeader("Message-ID", 
+    			"<" + UniqueValue.getUniqueMessageIDValue(session) + ">");
+    }
     }	
 
     /**


### PR DESCRIPTION
Currently, the API generates message-id and
uses it overriding the user provided message id.
https://github.com/eclipse-ee4j/mail/issues/432

This fix should be used with setHeader method.
addHeader method has the following issue
https://github.com/eclipse-ee4j/mail/issues/433
leading to the override despite this fix.

Signed-off-by: Venkat <subbaraocse9@gmail.com>