### PR TITLE
Android SocketChannel workaround not working around #403

### DIFF
--- a/mail/src/main/java/com/sun/mail/iap/Protocol.java
+++ b/mail/src/main/java/com/sun/mail/iap/Protocol.java
@@ -536,21 +536,61 @@ public class Protocol {
     public SocketChannel getChannel() {
 	SocketChannel ret = socket.getChannel();
 	if (ret != null)
-	    return ret;
+		return ret;
 
-	// XXX - Android is broken and SSL wrapped sockets don't delegate
-	// the getChannel method to the wrapped Socket
 	if (socket instanceof SSLSocket) {
-	    try {
-		Field f = socket.getClass().getDeclaredField("socket");
-		f.setAccessible(true);
-		Socket s = (Socket)f.get(socket);
-		ret = s.getChannel();
-	    } catch (Exception ex) {
-		// ignore anything that might go wrong
-	    }
+		ret = Protocol.findSocketChannel(socket);
 	}
 	return ret;
+    }
+
+    /**
+     * Android is broken and SSL wrapped sockets don't delegate
+     * the getChannel method to the wrapped Socket.
+     * 
+     * @param socket a non null socket
+     * @return the SocketChannel or null if not found
+     */
+    private static SocketChannel findSocketChannel(Socket socket) {
+	//Search class hierarchy for field name socket regardless of modifier.
+	for (Class<?> k = socket.getClass(); k != Object.class; k = k.getSuperclass()) {
+		try {
+			Field f = k.getDeclaredField("socket");
+			f.setAccessible(true);
+			Socket s = (Socket)f.get(socket);
+			SocketChannel ret = s.getChannel();
+			if (ret != null) {
+				return ret;
+			}
+		} catch (Exception ignore) {
+			//ignore anything that might go wrong
+		}
+	}
+	
+	//Search class hierarchy for fields that can hold a Socket
+	//or subclass regardless of modifier.  Fields declared as super types of Socket
+	//will be ignored.
+	for (Class<?> k = socket.getClass(); k != Object.class; k = k.getSuperclass()) {
+		try {
+			for (Field f : k.getDeclaredFields()) {
+				if (Socket.class.isAssignableFrom(f.getType())) {
+					try {
+						f.setAccessible(true);
+						Socket s = (Socket) f.get(socket);
+						SocketChannel ret = s.getChannel();
+						if (ret != null) {
+							return ret;
+						}
+					} catch (Exception ignore) {
+						//ignore anything that might go wrong
+					}
+				}
+			}
+		} catch (Exception ignore) {
+			//ignore anything that might go wrong
+		}
+	}
+	return null;
     }
 
     /**

--- a/mail/src/main/java/com/sun/mail/iap/Protocol.java
+++ b/mail/src/main/java/com/sun/mail/iap/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,7 +30,6 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 
 import com.sun.mail.util.PropUtil;
@@ -557,7 +556,7 @@ public class Protocol {
 		try {
 			Field f = k.getDeclaredField("socket");
 			f.setAccessible(true);
-			Socket s = (Socket)f.get(socket);
+			Socket s = (Socket) f.get(socket);
 			SocketChannel ret = s.getChannel();
 			if (ret != null) {
 				return ret;

--- a/mail/src/test/java/com/sun/mail/iap/ProtocolTest.java
+++ b/mail/src/test/java/com/sun/mail/iap/ProtocolTest.java
@@ -17,12 +17,22 @@
 package com.sun.mail.iap;
 
 import java.io.*;
+import java.lang.reflect.Method;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.SelectorProvider;
 import java.util.Properties;
+import java.util.Set;
 
 import com.sun.mail.test.NullOutputStream;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test the Protocol class.
@@ -81,5 +91,245 @@ public final class ProtocolTest {
 	p = new Protocol(nullis, nullps, props, false);
 	tag = p.writeCommand("CMD", null);
 	assertEquals("A0", tag);
+    }
+
+    @Test
+    public void testLayer1Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer1of5()) {
+                assertTrue(findSocketChannel(s) instanceof FakeSocketChannel);
+        }
+    }
+    
+    @Test
+    public void testLayer2Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer2of5()) {
+                assertTrue(findSocketChannel(s) instanceof FakeSocketChannel);
+        }
+    }
+    
+    @Test
+    public void testLayer3Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer3of5()) {
+                assertTrue(findSocketChannel(s) instanceof FakeSocketChannel);
+        }
+    }
+    
+    @Test
+    public void testLayer4Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer4of5()) {
+            assertTrue(findSocketChannel(s) instanceof FakeSocketChannel);
+        }
+    }
+    
+    @Test
+    public void testLayer5Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer5of5()) {
+            assertTrue(findSocketChannel(s) instanceof FakeSocketChannel);
+        }
+    }
+    
+    @Test
+    public void testRenamed1Socket() throws IOException, ProtocolException {
+        try (RenamedAbstractSocket s = new RenamedSocketLayer1of3()) {
+            assertTrue(findSocketChannel(s) instanceof FakeSocketChannel);
+        }
+    }
+    
+    @Test
+    public void testRenamed2Socket() throws IOException, ProtocolException {
+        try (RenamedAbstractSocket s = new RenamedSocketLayer2of3()) {
+                assertTrue(findSocketChannel(s) instanceof FakeSocketChannel);
+        }
+    }
+    
+    @Test
+    public void testRenamed3Socket() throws IOException, ProtocolException {
+        try (RenamedAbstractSocket s = new RenamedSocketLayer3of3()) {
+            assertTrue(findSocketChannel(s) instanceof FakeSocketChannel);
+        }
+    }
+    
+    @Test
+    public void testHidden1Socket() throws IOException, ProtocolException {
+        try (HiddenAbstractSocket s = new HiddenSocket1of2()) {
+            //This could be implemented to find the socket. 
+            //However, we would have fetch field value to inspect the object.
+            //Most reads will not be what we are looking for so best to give up.
+            //Feel free to change the policy later if needed.
+            assertNull(findSocketChannel(s));
+        }
+    }
+    
+    @Test
+    public void testHidden2Socket() throws IOException, ProtocolException {
+        try (HiddenAbstractSocket s = new HiddenSocket2of2()) {
+            //This could be implemented to find the socket. 
+            //However, we would have fetch field value to inspect the object.
+            //Most reads will not be what we are looking for so best to give up.
+            //Feel free to change the policy later if needed.
+            assertNull(findSocketChannel(s));
+        }
+    }
+    
+    private SocketChannel findSocketChannel(Socket s) throws IOException {
+        try {
+	    Method m = Protocol.class.getDeclaredMethod("findSocketChannel", Socket.class);
+	    m.setAccessible(true);
+	    return (SocketChannel) m.invoke((Object) null, s);
+	} catch (RuntimeException re) {
+	    throw re;
+	} catch (Exception e) {
+	    throw new IOException(e);
+	}
+    }
+    
+    private static class RenamedSocketLayer3of3 extends RenamedSocketLayer1of3 {
+    }
+    
+    private static class RenamedSocketLayer2of3 extends RenamedSocketLayer1of3 {
+    }
+    
+    private static class RenamedSocketLayer1of3 extends RenamedAbstractSocket {    
+    }
+    
+    private static abstract class RenamedAbstractSocket extends Socket {
+        @SuppressWarnings("unused") //Accessed via reflection.
+        private Socket tekcos = new WrappedSocket();
+    }
+    
+    private static class Layer5of5 extends Layer4of5 {
+    }
+    private static class Layer4of5 extends Layer3of5 {
+    }
+    private static class Layer3of5 extends Layer2of5 {
+    }
+    private static class Layer2of5 extends Layer1of5 {
+    }
+    private static class Layer1of5 extends LayerAbstractSocket {
+    }
+    
+    private static abstract class LayerAbstractSocket extends Socket {
+        @SuppressWarnings("unused") //Accessed via reflection.
+        private final Socket socket = new WrappedSocket();
+    }
+    
+    private static class WrappedSocket extends Socket {
+        @Override
+        public SocketChannel getChannel() {
+            return new FakeSocketChannel();
+        }
+    }
+    
+    private static class HiddenSocket2of2 extends HiddenSocket1of2 {
+    }
+    
+    private static class HiddenSocket1of2 extends HiddenAbstractSocket {
+    }
+    
+    private static abstract class HiddenAbstractSocket extends Socket {
+        @SuppressWarnings("unused") //Need to be present in case of access via reflection.
+        private final Object hidden = new WrappedSocket();
+    }
+    
+    private static class FakeSocketChannel extends SocketChannel {
+        
+        FakeSocketChannel() {
+            super((SelectorProvider) null);
+        }
+
+        @Override
+        public SocketChannel bind(SocketAddress local) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> SocketChannel setOption(SocketOption<T> name, T value) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SocketChannel shutdownInput() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SocketChannel shutdownOutput() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Socket socket() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isConnected() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isConnectionPending() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean connect(SocketAddress remote) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean finishConnect() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SocketAddress getRemoteAddress() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SocketAddress getLocalAddress() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected void implCloseSelectableChannel() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected void implConfigureBlocking(boolean block) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T getOption(SocketOption<T> name) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<SocketOption<?>> supportedOptions() {
+            throw new UnsupportedOperationException();
+        }
     }
 }


### PR DESCRIPTION
@bshannon I created a patch for this issue but at the moment I'm unable to build a test for it due to problems with my IDE setup.  I broke out the search logic into a private method so I can invoke it via reflection from the JUnit test.  Might take me a bit to create the test but wanted to at least give you a patch.