### PR TITLE
Fix javadoc build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -643,7 +643,7 @@
 		<plugin>
 		    <groupId>org.apache.felix</groupId>
 		    <artifactId>maven-bundle-plugin</artifactId>
-		    <version>3.5.0</version>
+		    <version>4.2.1</version>
 		</plugin>
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -663,11 +663,6 @@
 				<artifactId>jakarta.mail</artifactId>
 				<version>${mail.version}</version>
 			    </additionalDependency>
-			    <additionalDependency>
-				<groupId>com.sun.mail</groupId>
-				<artifactId>gimap</artifactId>
-				<version>${mail.version}</version>
-			    </additionalDependency>
 			</additionalDependencies>
 			<sourceFileExcludes>
 			    <sourceFileExclude>


### PR DESCRIPTION
also fixes #427 by making sure that API javadoc jar is not empty (as it was in RC5)