### PR TITLE
Remove fallback to system default charset solving #467

### DIFF
--- a/mail/src/main/java/jakarta/mail/internet/MimeUtility.java
+++ b/mail/src/main/java/jakarta/mail/internet/MimeUtility.java
@@ -1291,20 +1291,14 @@ public class MimeUtility {
 	    try {
 		defaultJavaCharset = System.getProperty("file.encoding", 
 							"8859_1");
-	    } catch (SecurityException sex) {
-		
-		class NullInputStream extends InputStream {
-		    @Override
-		    public int read() {
-			return 0;
-		    }
+		} catch (final SecurityException sex) {
+			// fall back to ISO-Latin-1
+			// don't use actual system encoding, because this might be
+			// something completely different, like EBCDIC (IBM-037)
+			if (defaultJavaCharset == null) {
+				defaultJavaCharset = "8859_1";
+			}
 		}
-		InputStreamReader reader = 
-			new InputStreamReader(new NullInputStream());
-		defaultJavaCharset = reader.getEncoding();
-		if (defaultJavaCharset == null)
-		    defaultJavaCharset = "8859_1";
-	    }
 	}
 
 	return defaultJavaCharset;


### PR DESCRIPTION
The MIME message is based on ASCII character set. Thus the default fallback encoding used to read MIME messages should be ASCII or at least based on ASCII. 

Using the OS' default encoding may result in using a completely different encoding. Most IBM machines (z-Series and AIX machines) use EBCDIC based encodings as default encoding und thus reading the messages fails.

Closes #467 

`
Signed-off-by: Olaf Neumann <eclipse@olafneumann.org>
`