### PR TITLE
Added back missing null check

### DIFF
--- a/mail/src/main/java/jakarta/mail/internet/MimeMessage.java
+++ b/mail/src/main/java/jakarta/mail/internet/MimeMessage.java
@@ -379,7 +379,10 @@ public class MimeMessage extends Message implements MimePart {
      */
     @Override
     public void setFrom(Address address) throws MessagingException {
-	setAddressHeader("From", new Address[] { address });
+        if (address == null)
+            removeHeader("From");
+        else
+            setAddressHeader("From", new Address[] { address });
     }
 
     /**
@@ -397,7 +400,10 @@ public class MimeMessage extends Message implements MimePart {
      * @since		JvaMail 1.5
      */
     public void setFrom(String address) throws MessagingException {
-	setAddressHeader("From", InternetAddress.parse(address));
+        if (address == null)
+            removeHeader("From");
+        else
+            setAddressHeader("From", InternetAddress.parse(address));
     }
 
     /**
@@ -479,7 +485,10 @@ public class MimeMessage extends Message implements MimePart {
      * @since		JavaMail 1.3
      */
     public void setSender(Address address) throws MessagingException {
-	setAddressHeader("Sender", new Address[] { address });
+        if (address == null)
+            removeHeader("Sender");
+        else
+            setAddressHeader("Sender", new Address[] { address });
     }
 
     /**


### PR DESCRIPTION
I have just restored the null checks from ac77368ae15f4a0092499a4e939fe58c21325f37, as it is described in the javadocs:

> If address is null, this header is removed.


Closes #456 