### PR TITLE
Move the build to require JDK 11

### DIFF
--- a/copyright-exclude
+++ b/copyright-exclude
@@ -12,8 +12,7 @@ doc/spec/
 CONTRIBUTING.md
 LICENSE.md
 client/src/main/java/simple.mailcap
-mail/src/oldtest/java/javax/mail/internet/encodedheaders.data
-mail/src/oldtest/java/javax/mail/internet/decodetest
+mail/src/oldtest/java/jakarta/mail/internet/encodedheaders.data
 mail.sig
 webapp/build.bat
 webapp/webapp.README.txt

--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -25,6 +25,8 @@ longer available.
 The following bugs have been fixed in the 2.0.1 release.
 
 E  456	MimeMessage.setFrom(null) fails instead of removing the header
+E  473	Several modules are not included in build when JDK11 is used
+E  493	javamail.providers file missing from provider jars after 1.6.5
 
 
 		  CHANGES IN THE 2.0.0 RELEASE

--- a/dsn/pom.xml
+++ b/dsn/pom.xml
@@ -70,9 +70,7 @@
 	<dependency>
 	    <groupId>junit</groupId>
 	    <artifactId>junit</artifactId>
-	    <version>4.13.1</version>
 	    <scope>test</scope>
-	    <optional>true</optional>
 	</dependency>
     </dependencies>
 

--- a/dsn/src/main/java/module-info.java
+++ b/dsn/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,12 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-module com.sun.mail.imap {
-    exports com.sun.mail.iap;
-    exports com.sun.mail.imap;
-    exports com.sun.mail.imap.protocol;
-    provides jakarta.mail.Provider with
-	com.sun.mail.imap.IMAPProvider, com.sun.mail.imap.IMAPSSLProvider;
+module com.sun.mail.dsn {
+    exports com.sun.mail.dsn;
 
     requires transitive jakarta.mail;
 }

--- a/gimap/pom.xml
+++ b/gimap/pom.xml
@@ -64,9 +64,8 @@
     <dependencies>
 	<!--
 	    Even though gimap.jar works with either the full jakarta.mail.jar
-	    or th mailapi.jar, we need to get the API definitions from
-	    mailapi.jar because it includes a module-info.class, which
-	    allows this to compile under JDK 11+.
+	    or th mailapi.jar, we want to get the API definitions from
+	    mailapi.jar.
 	-->
         <dependency>
             <groupId>com.sun.mail</groupId>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>imap</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/gimap/src/main/java/module-info.java
+++ b/gimap/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,8 +21,14 @@ module com.sun.mail.gimap {
 	com.sun.mail.gimap.GmailProvider, com.sun.mail.gimap.GmailSSLProvider;
 
     requires jakarta.mail;
-    requires jakarta.activation;
-    requires java.logging;
-    requires java.security.sasl;
-    requires com.sun.mail.imap;
+    /*
+    following is intentionally optional/static for gimap module to work
+    with com.sun.mail:jakarta.mail (all-in-one bundle jar)
+    as well as with com.sun.mail:mailapi + com.sun.mail:imap
+    the latter deps come through maven dependency tree, therefore
+    they must be explicitely excluded if the former is being used
+    to avoid having two jars having same 'jakarta.mail' module name
+    in the environement
+    */
+    requires static com.sun.mail.imap;
 }

--- a/imap/pom.xml
+++ b/imap/pom.xml
@@ -42,19 +42,4 @@
 	</mail.packages.export>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <skipMain>false</skipMain>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -37,28 +37,105 @@
     <build>
         <plugins>
 	    <!--
-		To allow us to generate javadocs that only include some
-		classes in certain packages, we need to copy the sources
-		to another location and run javadoc against that subset
-		of the sources.  This ant task does the copy.
+		To allow us to generate aggregated javadocs that only include some
+		classes in certain packages from certain modules, we need to copy the sources
+		to another location and run javadoc against that set
+		of the sources. This gets sources.
 	    -->
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- download the sources -->
+                        <id>get-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.sun.mail</groupId>
+                                    <artifactId>jakarta.mail</artifactId>
+                                    <version>${mail.version}</version>
+                                    <classifier>sources</classifier>
+                                    <outputDirectory>
+                                        ${project.build.directory}/javadoc-sources/jakarta.mail
+                                    </outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.mail</groupId>
+                                    <artifactId>dsn</artifactId>
+                                    <version>${mail.version}</version>
+                                    <classifier>sources</classifier>
+                                    <outputDirectory>
+                                        ${project.build.directory}/javadoc-sources/com.sun.mail.dsn
+                                    </outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.mail</groupId>
+                                    <artifactId>gimap</artifactId>
+                                    <version>${mail.version}</version>
+                                    <classifier>sources</classifier>
+                                    <outputDirectory>
+                                        ${project.build.directory}/javadoc-sources/com.sun.mail.gimap
+                                    </outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+                We want to produce aggregated javadoc for multiple JPMS modules. To do that
+                we have to pass 'module-source-path' to javadoc tool to make it module aware.
+                While we can pass that option to javadoc through maven-javadoc-plugin
+                using 'additionalOptions', the plugin also sets 'sourcepath' option,
+                which is in conflict with 'module-source-path' (as of maven-javadoc-plugin:3.2.0).
+                Ant task is used here to get around that limitation for the time being.
+            -->
 	    <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-		<inherited>false</inherited>
                 <executions>
 		    <execution>
 			<phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
 			<configuration>
-			    <tasks>
+                            <target>
+                                <replace file="${project.build.directory}/javadoc-sources/com.sun.mail.gimap/module-info.java"
+                                         token="requires static com.sun.mail.imap;"
+                                         value=""/>
+                                <mkdir dir="${project.build.directory}/javadoc-ant"/>
+                                <javadoc destdir="${project.build.directory}/site/apidocs"
+                                         modulesourcepath="${project.build.directory}/javadoc-sources/"
+                                         modulepath="${com.sun.activation:jakarta.activation:jar}"
+                                         author="false"
+                                         docfilessubdirs="true"
+                                         failonerror="true"
+                                         overview="${project.build.directory}/javadoc-sources/jakarta.mail/overview.html"
+                                         serialwarn="true"
+                                         source="11"
+                                         splitindex="true"
+                                         use="true"
+                                         >
+                                    <arg value="-J-Xmx256m" />
+                                    <arg value="-Xdoclint:none" />
+                                    <arg value="-notimestamp" />
+                                    <arg value="-quiet" />
+                                    <arg line="-windowtitle '${mail.javadoc.title}'" />
+                                    <doctitle>${mail.javadoc.title}</doctitle>
+                                    <bottom>${mail.javadoc.bottom}</bottom>
+                                    <header>${mail.javadoc.impl.header}</header>
+                                    <group title="Jakarta Mail API Packages" packages="jakarta.mail.*"/>
+                                    <group title="Implementation-specific Packages" packages="com.sun.mail.*"/>
 
-				<copy todir="target/javadoc">
-				    <fileset dir="../mail/src/main/java">
-					<include name="**/*.html"/>
+                                    <fileset dir="${project.build.directory}/javadoc-sources/jakarta.mail">
 					<include name="jakarta/mail/**"/>
 				    </fileset>
-				    <fileset dir="../mail/src/main/java"
+                                    <fileset dir="${project.build.directory}/javadoc-sources/jakarta.mail"
 					includes="
-			com/sun/mail/imap/package.html,
 			com/sun/mail/imap/IMAPFolder.java,
 			com/sun/mail/imap/IMAPMessage.java,
 			com/sun/mail/imap/IMAPStore.java,
@@ -90,91 +167,20 @@
 			com/sun/mail/util/ReadableMime.java,
 			com/sun/mail/util/logging/*.java
 					"/>
-				    <fileset dir="../dsn/src/main/java"
+                                    <fileset dir="${project.build.directory}/javadoc-sources/com.sun.mail.dsn"
 					includes="
-			com/sun/mail/dsn/package.html,
 			com/sun/mail/dsn/DeliveryStatus.java,
 			com/sun/mail/dsn/DispositionNotification.java,
 			com/sun/mail/dsn/MessageHeaders.java,
 			com/sun/mail/dsn/MultipartReport.java,
 			com/sun/mail/dsn/Report.java
 					"/>
-				    <fileset dir="../gimap/src/main/java"
+                                    <fileset dir="${project.build.directory}/javadoc-sources/com.sun.mail.gimap"
 					includes="
-			com/sun/mail/gimap/package.html,
 			com/sun/mail/gimap/*.java
 					"/>
-				</copy>
-
-			    </tasks>
-			</configuration>
-			<goals>
-			    <goal>run</goal>
-			</goals>
-		    </execution>
-                </executions>
-            </plugin>                                 
-
-	    <plugin>
-		<artifactId>maven-javadoc-plugin</artifactId>
-		<inherited>false</inherited>
-                <executions>
-		    <execution>
-			<phase>package</phase>
-			<goals>
-			    <goal>javadoc</goal>
-			</goals>
-			<configuration>
-			    <additionalJOption>-J-Xmx256m</additionalJOption>
-			    <author>false</author>
-			    <description>
-				Jakarta Mail API documentation
-			    </description>
-			    <doctitle>
-				Jakarta Mail API documentation
-			    </doctitle>
-			    <windowtitle>
-				Jakarta Mail API documentation
-			    </windowtitle>
-			    <splitindex>true</splitindex>
-			    <use>true</use>
-			    <notimestamp>true</notimestamp>
-			    <serialwarn>true</serialwarn>
-			    <quiet>true</quiet>
-			    <overview>
-				${basedir}/target/javadoc/overview.html
-			    </overview>
-			    <bottom>
-<![CDATA[Copyright &#169; 2019, 2020 Eclipse Foundation.
-    Use is subject to
-    <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
-]]>
-			    </bottom>
-			    <groups>
-				<group>
-				    <title>Jakarta Mail API Packages</title>
-				    <packages>jakarta.*</packages>
-				</group>
-				<group>
-				    <title>Implementation-specific Packages</title>
-				    <packages>com.sun.*</packages>
-				</group>
-			    </groups>
-			    <!--
-				Force javadoc to produce non-module docs
-				since the module definition isn't part of
-				the API specification.
-			    -->
-			    <source>8</source>
-			    <sourceFileExcludes>
-				<sourceFileExclude>module-info.java</sourceFileExclude>
-				<sourceFileExclude>com/sun/mail/imap/protocol/**</sourceFileExclude>
-				<sourceFileExclude>com/sun/mail/gimap/protocol/**</sourceFileExclude>
-			    </sourceFileExcludes>
-			    <!-- force the doc-files directory to be copied -->
-			    <docfilessubdirs>true</docfilessubdirs>
-			    <detectJavaApiLink>false</detectJavaApiLink>
-			    <sourcepath>${basedir}/target/javadoc</sourcepath>
+                                </javadoc>
+                            </target>
 			</configuration>
 		    </execution>
                 </executions>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -67,73 +67,63 @@
 	</findbugs.exclude>
     </properties>
 
-    <profiles>
-	<!--
-	    A special profile for compiling with the real JDK 1.7 compiler.
-	    Exclude MailSessionDefinition and MailSessionDefinitions since
-	    the former requires JDK 1.8 and the latter depends on the former.
-	-->
-	<profile>
-	    <id>1.7</id>
-	    <activation>
-		<jdk>1.7</jdk>
-	    </activation>
-	    <build>
-		<plugins>
-		    <plugin>
-			<artifactId>maven-compiler-plugin</artifactId>
-			<executions>
-			    <execution>
-				<id>default-compile</id>
-				<configuration>
-				    <excludes>
-					<exclude>
-					  jakarta/mail/MailSessionDefinition.java
-					</exclude>
-					<exclude>
-					  jakarta/mail/MailSessionDefinitions.java
-					</exclude>
-					<exclude>
-					  module-info.java
-					</exclude>
-				    </excludes>
-				</configuration>
-			    </execution>
-			</executions>
-		    </plugin>
-		</plugins>
-	    </build>
-	</profile>
-
-    </profiles>
-
     <build>
 	<resources>
 	    <resource>
 		<directory>src/main/resources</directory>
 		<filtering>true</filtering>
+                <excludes>
+                    <exclude>jakarta/mail/Version.java</exclude>
+                </excludes>
 	    </resource>
 	</resources>
 	<plugins>
-	    <!--
-		Configure compiler plugin to print lint warnings.
-		Need to exclude options warning because bootstrap
-		classpath isn't set (on purpose).
-		Need to exclude path warnings because Maven includes
-		source directories that don't exist (e.g., generated-sources).
-	    -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/generated-sources/version</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>jakarta/mail/Version.java</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+                Use 1.8 compiler to compile MailServiceDefinition & MailServiceDefinitions
+                which depend on the Repeatable annotation available from Java SE 8
+            -->
 	    <plugin>
 		<artifactId>maven-compiler-plugin</artifactId>
-		<configuration>
-		    <compilerArgs>
-			<arg>-Xlint</arg>
-			<arg>-Xlint:-options</arg>
-			<arg>-Xlint:-path</arg>
-			<!--<arg>-Werror</arg>-->
-		    </compilerArgs>
-		    <showDeprecation>true</showDeprecation>
-		    <showWarnings>true</showWarnings>
-		</configuration>
+                <executions>
+                    <execution>
+                        <id>base-compile-8</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>8</release>
+                            <includes>
+                                <include>jakarta/mail/MailSessionDefinition.java</include>
+                                <include>jakarta/mail/MailSessionDefinitions.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
 	    </plugin>
 
 	    <!--
@@ -150,32 +140,11 @@
 		</configuration>
 	    </plugin>
 
-	    <!--
-		Add the Automatic-Module-Name manifest header for JDK 9.
-	    -->
-	    <plugin>
-		<artifactId>maven-jar-plugin</artifactId>
-		<configuration>
-		    <archive>
-			<manifestEntries>
-			    <Automatic-Module-Name>
-				${mail.moduleName}
-			    </Automatic-Module-Name>
-			</manifestEntries>
-		    </archive>
-		</configuration>
-	    </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <docfilessubdirs>true</docfilessubdirs>
-                    <javadocDirectory>${main.basedir}/mail/src/main/java</javadocDirectory>
-                    <bottom>
-<![CDATA[Copyright &#169; 2019, 2020 Eclipse Foundation.<br>
-    Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
-]]>
-                    </bottom>
+                    <bottom>${mail.javadoc.bottom}</bottom>
                 </configuration>
             </plugin>
         </plugins>
@@ -189,9 +158,7 @@
 	<dependency>
 	    <groupId>junit</groupId>
 	    <artifactId>junit</artifactId>
-	    <version>4.13.1</version>
 	    <scope>test</scope>
-	    <optional>true</optional>
 	</dependency>
     </dependencies>
 </project>

--- a/mail/src/main/java/com/sun/mail/imap/protocol/UIDSet.java
+++ b/mail/src/main/java/com/sun/mail/imap/protocol/UIDSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/mail/src/main/java/com/sun/mail/smtp/DigestMD5.java
+++ b/mail/src/main/java/com/sun/mail/smtp/DigestMD5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/mail/src/main/java/module-info.java
+++ b/mail/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,6 +15,7 @@
  */
 
 module jakarta.mail {
+
     exports jakarta.mail;
     exports jakarta.mail.event;
     exports jakarta.mail.internet;
@@ -24,10 +25,28 @@ module jakarta.mail {
     exports com.sun.mail.auth;
     exports com.sun.mail.handlers;
 
+    exports com.sun.mail.iap;
+    exports com.sun.mail.imap;
+    exports com.sun.mail.imap.protocol;
+
+    exports com.sun.mail.pop3;
+
+    exports com.sun.mail.smtp;
+
+    exports com.sun.mail.util.logging;
+
     requires transitive jakarta.activation;
     requires transitive java.logging;
     requires java.xml;		// for text/xml handler
     requires java.desktop;	// for image/jpeg handler
     requires transitive java.security.sasl; // for OAuth2 support
     uses jakarta.mail.Provider;
+
+    provides jakarta.mail.Provider with
+            com.sun.mail.imap.IMAPProvider,
+            com.sun.mail.imap.IMAPSSLProvider,
+            com.sun.mail.smtp.SMTPProvider,
+            com.sun.mail.smtp.SMTPSSLProvider,
+            com.sun.mail.pop3.POP3Provider,
+            com.sun.mail.pop3.POP3SSLProvider;
 }

--- a/mail/src/oldtest/java/jakarta/mail/internet/decodetest
+++ b/mail/src/oldtest/java/jakarta/mail/internet/decodetest
@@ -1,4 +1,20 @@
 #!/bin/sh
+#
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
 java decodetext < encodedheaders.data > x1
 java -Dmail.mime.decodetext.strict=false decodetext < encodedheaders.data > x2
 diff -c x1 x2

--- a/mail/src/oldtest/java/jakarta/mail/internet/socketfactory/DummySSLSocketFactory.java
+++ b/mail/src/oldtest/java/jakarta/mail/internet/socketfactory/DummySSLSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/mail/src/oldtest/java/jakarta/mail/internet/socketfactory/DummySocketFactory.java
+++ b/mail/src/oldtest/java/jakarta/mail/internet/socketfactory/DummySocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/mail/src/oldtest/java/jakarta/mail/internet/socketfactory/DummyTrustManager.java
+++ b/mail/src/oldtest/java/jakarta/mail/internet/socketfactory/DummyTrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/mail/src/oldtest/java/jakarta/mail/internet/socketfactory/TestResult.java
+++ b/mail/src/oldtest/java/jakarta/mail/internet/socketfactory/TestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/mail/src/test/java/jakarta/mail/internet/MimeMultipartBCSIndexTest.java
+++ b/mail/src/test/java/jakarta/mail/internet/MimeMultipartBCSIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/mailapi/pom.xml
+++ b/mailapi/pom.xml
@@ -95,14 +95,6 @@
 		<artifactId>maven-dependency-plugin</artifactId>
 		<executions>
 		    <execution>
-			<!-- download the binaries -->
-			<id>get-binaries</id>
-			<phase>generate-sources</phase>
-			<goals>
-			    <goal>unpack</goal>
-			</goals>
-		    </execution>
-		    <execution>
 			<!-- download the sources -->
 			<id>get-sources</id>
 			<phase>generate-sources</phase>
@@ -117,84 +109,68 @@
 				    <version>${mail.version}</version>
 				    <classifier>sources</classifier>
 				    <outputDirectory>
-					${project.build.directory}/sources
+					${project.build.directory}/generated-sources/sources
 				    </outputDirectory>
 				</artifactItem>
 			    </artifactItems>
-			</configuration>
-		    </execution>
-		</executions>
-		<configuration>
-		    <artifactItems>
-			<artifactItem>
-			    <groupId>com.sun.mail</groupId>
-			    <artifactId>jakarta.mail</artifactId>
-			    <version>${mail.version}</version>
-			</artifactItem>
-		    </artifactItems>
-		    <outputDirectory>
-			${project.build.outputDirectory}
-		    </outputDirectory>
 		    <!--
-			Include all the implementation source files so that
-			javadoc run as part of "deploy" will find all the
-			required classes.
+                        Don't include the provider classes in the jar file.
 
 			Don't include the metadata files from the original
 			jar file.
 		    -->
-		    <excludes>
-			META-INF/hk2-locator/**,
-			META-INF/services/**,
-			META-INF/maven/**,
-			META-INF/javamail.**,
-			META-INF/gfprobe-provider.xml
-		    </excludes>
-		</configuration>
-	    </plugin>
+                            <excludes>
+                                module-info.*,
+                                **/iap/**,
+                                **/imap/**,
+                                **/smtp/**,
+                                **/pop3/**,
+                                META-INF/hk2-locator/**,
+                                META-INF/services/**,
+                                META-INF/maven/**,
+                                META-INF/javamail.**,
+                                META-INF/gfprobe-provider.xml
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-	    <!--
-		 Skip compiling since the dependency plugin pulled in
-		 the sources and class files.
-	    -->
+            <!--
+                Use 1.8 compiler to compile MailServiceDefinition & MailServiceDefinitions
+                which depend on the Repeatable annotation available from Java SE 8
+            -->
 	    <plugin>
 		<artifactId>maven-compiler-plugin</artifactId>
 		<executions>
 		    <execution>
-			<id>default-compile</id>
+			<id>base-compile-8</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
 			<configuration>
-			    <skipMain>true</skipMain>
+                            <release>8</release>
+                            <includes>
+                                <include>jakarta/mail/MailSessionDefinition.java</include>
+                                <include>jakarta/mail/MailSessionDefinitions.java</include>
+                            </includes>
 			</configuration>
 		    </execution>
 		</executions>
 	    </plugin>
 
-	    <!--
-		Don't include the provider classes in the jar file.
-	    -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <finalName>${project.artifactId}</finalName>
-		    <excludes>
-			<exclude>com/sun/mail/smtp/**</exclude>
-			<exclude>com/sun/mail/imap/**</exclude>
-			<exclude>com/sun/mail/iap/**</exclude>
-			<exclude>com/sun/mail/pop3/**</exclude>
-		    </excludes>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <docfilessubdirs>true</docfilessubdirs>
-                    <javadocDirectory>${main.basedir}/mail/src/main/java</javadocDirectory>
-                    <bottom>
-<![CDATA[Copyright &#169; 2019, 2020 Eclipse Foundation.<br>
-    Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
-]]>
-                    </bottom>
+                    <bottom>${mail.javadoc.bottom}</bottom>
+                    <javadocDirectory>${project.build.directory}/generated-sources/sources</javadocDirectory>
                 </configuration>
             </plugin>
 	</plugins>

--- a/mailapijar/pom.xml
+++ b/mailapijar/pom.xml
@@ -22,6 +22,12 @@
     the jakarta.mail.* API definitions and is *only* intended to be used
     for programs to compile against.  Note that it includes none of the
     implementation-specific classes that the jakarta.mail.* classes rely on.
+
+    NOTE: Because the jar still has to be usable on Java SE 8 and/or
+    on the classpath, implementation-specific com.sun classes are not included.
+    Therefore putting this file on the module-path may not work as expected.
+    To fix this, com.sun classes need to be added to the jar file
+    while the JPMS descriptor needs to be kept as-is.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -61,6 +67,7 @@
 	<mail.moduleName>
 	    jakarta.mail
 	</mail.moduleName>
+        <mail.recompile.skip>true</mail.recompile.skip>
     </properties>
 
     <build>
@@ -75,6 +82,18 @@
 			<goals>
 			    <goal>unpack</goal>
 			</goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.sun.mail</groupId>
+                                    <artifactId>jakarta.mail</artifactId>
+                                    <version>${mail.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>
+                                ${project.build.outputDirectory}
+                            </outputDirectory>
+                        </configuration>
 		    </execution>
 		    <execution>
 			<!-- download the sources -->
@@ -91,7 +110,7 @@
 				    <version>${mail.version}</version>
 				    <classifier>sources</classifier>
 				    <outputDirectory>
-					${project.build.directory}/sources
+					${project.build.directory}/generated-sources/sources
 				    </outputDirectory>
 				</artifactItem>
 			    </artifactItems>
@@ -99,16 +118,6 @@
 		    </execution>
 		</executions>
 		<configuration>
-		    <artifactItems>
-			<artifactItem>
-			    <groupId>com.sun.mail</groupId>
-			    <artifactId>jakarta.mail</artifactId>
-			    <version>${mail.version}</version>
-			</artifactItem>
-		    </artifactItems>
-		    <outputDirectory>
-			${project.build.outputDirectory}
-		    </outputDirectory>
 		    <!--
 			Include all the implementation source files so that
 			javadoc run as part of "deploy" will find all the
@@ -118,6 +127,7 @@
 			jar file.
 		    -->
 		    <excludes>
+                        module-info.*,
 			META-INF/**
 		    </excludes>
 		</configuration>
@@ -126,20 +136,21 @@
 	    <!--
 		 Skip compiling since the dependency plugin pulled in
 		 the sources and class files.
+                 We only need to compile JPMS descriptor.
 	    -->
 	    <plugin>
 		<artifactId>maven-compiler-plugin</artifactId>
 		<executions>
 		    <execution>
-			<id>default-compile</id>
+                        <id>module-info-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
 			<configuration>
-			    <skipMain>true</skipMain>
-			    <!--
-				The following prevents Maven from trying to
-				compile the sources downloaded by a previous
-				run of Maven.
-			    -->
-			    <useIncrementalCompilation>false</useIncrementalCompilation>
+                            <release>11</release>
+                            <includes>
+                                <include>module-info.java</include>
+                            </includes>
 			</configuration>
 		    </execution>
 		</executions>
@@ -155,28 +166,30 @@
 		    <excludes>
 			<exclude>com/**</exclude>
 		    </excludes>
-		    <archive>
-			<manifestEntries>
-			    <Automatic-Module-Name>
-				${mail.moduleName}
-			    </Automatic-Module-Name>
-			</manifestEntries>
-		    </archive>
                 </configuration>
             </plugin>
+
+	    <!--
+		Don't include the implementation sources in the jar file.
+	    -->
+	    <plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-source-plugin</artifactId>
+		<configuration>
+		    <excludes>
+			<exclude>com/**</exclude>
+		    </excludes>
+		</configuration>
+	    </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <docfilessubdirs>true</docfilessubdirs>
-                    <javadocDirectory>${main.basedir}/mail/src/main/java</javadocDirectory>
                     <excludePackageNames>com.sun.*</excludePackageNames>
-                    <bottom>
-<![CDATA[Copyright &#169; 2019, 2020 Eclipse Foundation.<br>
-    Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
-]]>
-                    </bottom>
+                    <bottom>${mail.javadoc.bottom}</bottom>
+                    <header>${mail.javadoc.api.header}</header>
+                    <javadocDirectory>${project.build.directory}/generated-sources/sources</javadocDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/mailapijar/src/main/java/module-info.java
+++ b/mailapijar/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,12 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-module com.sun.mail.imap {
-    exports com.sun.mail.iap;
-    exports com.sun.mail.imap;
-    exports com.sun.mail.imap.protocol;
-    provides jakarta.mail.Provider with
-	com.sun.mail.imap.IMAPProvider, com.sun.mail.imap.IMAPSSLProvider;
+module jakarta.mail {
 
-    requires transitive jakarta.mail;
+    exports jakarta.mail;
+    exports jakarta.mail.event;
+    exports jakarta.mail.internet;
+    exports jakarta.mail.search;
+    exports jakarta.mail.util;
+
+    requires transitive jakarta.activation;
+    requires transitive java.logging;
 }

--- a/mailhandler/src/main/java/module-info.java
+++ b/mailhandler/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,5 @@
 module com.sun.mail.util.logging {
     exports com.sun.mail.util.logging;
 
-    requires jakarta.mail;
-    requires java.logging;
+    requires transitive jakarta.mail;
 }

--- a/mbox/pom.xml
+++ b/mbox/pom.xml
@@ -44,24 +44,6 @@
 	</findbugs.exclude>
     </properties>
 
-    <build>
-	<plugins>
-	    <!--
-		Configure test plugin to find *TestSuite classes.
-	    -->
-	    <plugin>
-		<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-surefire-plugin</artifactId>
-		<configuration>
-		    <includes>
-			<include>**/*Test.java</include>
-			<include>**/*TestSuite.java</include>
-		    </includes>
-		</configuration>
-	    </plugin>
-	</plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>com.sun.mail</groupId>
@@ -70,9 +52,7 @@
 	<dependency>
 	    <groupId>junit</groupId>
 	    <artifactId>junit</artifactId>
-	    <version>4.13.1</version>
 	    <scope>test</scope>
-	    <optional>true</optional>
 	</dependency>
     </dependencies>
 </project>

--- a/mbox/src/main/java/module-info.java
+++ b/mbox/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,12 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-module com.sun.mail.imap {
-    exports com.sun.mail.iap;
-    exports com.sun.mail.imap;
-    exports com.sun.mail.imap.protocol;
-    provides jakarta.mail.Provider with
-	com.sun.mail.imap.IMAPProvider, com.sun.mail.imap.IMAPSSLProvider;
+module com.sun.mail.mbox {
+    exports com.sun.mail.mbox;
+    exports com.sun.mail.remote;
 
     requires transitive jakarta.mail;
 }

--- a/parent-distrib/pom.xml
+++ b/parent-distrib/pom.xml
@@ -44,14 +44,6 @@
 		<artifactId>maven-dependency-plugin</artifactId>
 		<executions>
 		    <execution>
-			<!-- download the binaries -->
-			<id>get-binaries</id>
-			<phase>generate-sources</phase>
-			<goals>
-			    <goal>unpack</goal>
-			</goals>
-		    </execution>
-		    <execution>
 			<!-- download the sources -->
 			<id>get-sources</id>
 			<phase>generate-sources</phase>
@@ -66,7 +58,7 @@
 				    <version>${mail.version}</version>
 				    <classifier>sources</classifier>
 				    <outputDirectory>
-					${project.build.directory}/sources
+					${project.build.directory}/generated-sources/sources
 				    </outputDirectory>
 				</artifactItem>
 			    </artifactItems>
@@ -74,67 +66,12 @@
 		    </execution>
 		</executions>
 		<configuration>
-		    <artifactItems>
-			<artifactItem>
-			    <groupId>com.sun.mail</groupId>
-			    <artifactId>jakarta.mail</artifactId>
-			    <version>${mail.version}</version>
-			</artifactItem>
-		    </artifactItems>
-		    <outputDirectory>
-			${project.build.outputDirectory}
-		    </outputDirectory>
-		    <!--
-			Include all the implementation source files so that
-			javadoc run as part of "deploy" will find all the
-			required classes.
-
-			Don't include the metadata files from the original
-			jar file.
-		    -->
-		    <excludes>
-			META-INF/**
-		    </excludes>
-		</configuration>
-	    </plugin>
-
-	    <!--
-		 Skip compiling since the dependency plugin pulled in
-		 the sources and class files.
-	    -->
-	    <plugin>
-		<artifactId>maven-compiler-plugin</artifactId>
-		<executions>
-		    <execution>
-			<id>default-compile</id>
-			<configuration>
-			    <skipMain>true</skipMain>
-			    <!--
-				The following prevents Maven from trying to
-				compile the sources downloaded by a previous
-				run of Maven.
-			    -->
-			    <useIncrementalCompilation>false</useIncrementalCompilation>
-			</configuration>
-		    </execution>
-		</executions>
-	    </plugin>
-
-	    <!--
-		Include the implementation classes in the jar files.
-	    -->
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <finalName>${project.artifactId}</finalName>
 		    <includes>
-			<include>module-info.class</include>
-			<include>${mail.classes}</include>
-			<include>${mail.extraClasses}</include>
+                        ${mail.classes},
+                        ${mail.extraClasses}
 		    </includes>
                 </configuration>
             </plugin>
-
 	</plugins>
     </build>
 
@@ -142,7 +79,6 @@
 	<dependency>
 	    <groupId>com.sun.mail</groupId>
 	    <artifactId>mailapi</artifactId>
-	    <version>${mail.version}</version>
 	</dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,17 @@
 	    com.sun.mail.*
 	</mail.packages.private>
 	<mail.probeFile/>
+        <mail.recompile.skip>false</mail.recompile.skip>
+        <mail.javadoc.bottom><![CDATA[
+Comments to : <a href="mailto:mail-dev@eclipse.org">mail-dev@eclipse.org</a>.<br>
+Copyright &#169; 2019, 2021 Eclipse Foundation. All rights reserved.<br>
+Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
+        </mail.javadoc.bottom>
+        <mail.javadoc.api.header><![CDATA[<br>Jakarta Mail API v${project.version}]]></mail.javadoc.api.header>
+        <mail.javadoc.impl.header><![CDATA[<br>Jakarta Mail v${project.version}]]></mail.javadoc.impl.header>
+        <mail.javadoc.title>
+            Jakarta Mail API documentation
+        </mail.javadoc.title>
 	<!-- for the osgiversion-maven-plugin -->
 	<hk2.plugin.version>2.0.0</hk2.plugin.version>
 	<javac.path>/opt/jdk1.7/bin/javac</javac.path>
@@ -114,7 +125,7 @@
 	    true
 	</findbugs.skip>
 	<findbugs.exclude/>
-        <copyright-plugin.version>1.46</copyright-plugin.version>
+        <copyright-plugin.version>2.4</copyright-plugin.version>
     </properties>
 
     <developers>
@@ -247,95 +258,17 @@
 		</plugins>
 	    </build>
 	</profile>
-
-	<!--
-	    A special profile for compiling with JDK 11+.
-	-->
-	<profile>
-	    <id>11</id>
-	    <activation>
-		<jdk>11</jdk>
-	    </activation>
-	    <build>
-		<plugins>
-		    <plugin>
-			<artifactId>maven-compiler-plugin</artifactId>
-			<executions>
-			    <execution>
-				<id>default-compile</id>
-				<configuration>
-                                    <release>9</release>
-				</configuration>
-			    </execution>
-			    <execution>
-				<id>base-compile</id>
-				<goals>
-				    <goal>compile</goal>
-				</goals>
-				<configuration>
-				    <release>8</release>
-				    <excludes>
-					<exclude>module-info.java</exclude>
-				    </excludes>
-				    <compilerArgs>
-					<arg>-Xlint</arg>
-					<arg>-Xlint:-options</arg>
-					<arg>-Xlint:-path</arg>
-					<!--
-					    Too many finalize warnings.
-					<arg>-Werror</arg>
-					-->
-				    </compilerArgs>
-				</configuration>
-			    </execution>
-			    <execution>
-				<id>default-testCompile</id>
-				<configuration>
-				    <release>9</release>
-				</configuration>
-			    </execution>
-			</executions>
-		    </plugin>
-		    <!--
-			Require JDK 11.
-		    -->
-		    <plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-enforcer-plugin</artifactId>
-			<executions>
-			    <execution>
-				<id>enforce-version</id>
-				<goals>
-				    <goal>enforce</goal>
-				</goals>
-				<configuration>
-				    <rules>
-					<requireMavenVersion>
-					    <version>[3.0.3,)</version>
-					</requireMavenVersion>
-					<requireJavaVersion>
-					    <version>[11,)</version>
-					</requireJavaVersion>
-				    </rules>
-				</configuration>
-			    </execution>
-			</executions>
-		    </plugin>
-		</plugins>
-	    </build>
-	</profile>
     </profiles>
 
     <build>
 	<defaultGoal>install</defaultGoal>
 	<plugins>
 	    <!--
-		Make sure we're using the correct version of maven.
+		Make sure we're using the correct version of maven and JDK.
 	    -->
 	    <plugin>
 		<groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-enforcer-plugin</artifactId>
-		    <version>3.0.0-M1</version>
 		<executions>
 		    <execution>
 			<id>enforce-version</id>
@@ -348,7 +281,7 @@
 				    <version>[3.0.3,)</version>
 				</requireMavenVersion>
 				<requireJavaVersion>
-				    <version>1.8</version>
+				    <version>[11,)</version>
 				</requireJavaVersion>
 			    </rules>
 			</configuration>
@@ -427,10 +360,12 @@
 	    </plugin>
 
 	    <!--
-		Use the 1.8 compiler for Jakarta Mail itself and the test classes,
+		Use the JDK 11+ compiler for Jakarta Mail itself,
 		but restrict it to 1.7 source and target.  The 1.8 compiler is
 		used *only* to pick up the definition of the Repeatable
-		annotation, needed by MailServiceDefinition.
+		annotation, needed by MailServiceDefinition(s) on places where it is needed
+                and the test classes.
+                The 11+ compiler is used *only* to compile module-info descriptors.
 	    -->
 	    <plugin>
 		<artifactId>maven-compiler-plugin</artifactId>
@@ -438,21 +373,51 @@
 		    <execution>
 			<id>default-compile</id>
 			<configuration>
-			    <source>1.7</source>
-			    <target>1.7</target>
-			    <!--
-				XXX - workaround for bug in maven compiler
-				plugin versions 3.0 - 3.3 (at least):
-				https://issues.apache.org/jira/browse/MCOMPILER-209
-			    -->
-			    <useIncrementalCompilation>false</useIncrementalCompilation>
+                            <skipMain>${mail.recompile.skip}</skipMain>
+                            <release>9</release>
+                            <showDeprecation>true</showDeprecation>
+                            <showWarnings>true</showWarnings>
+                            <!--
+                                Configure compiler plugin to print lint warnings.
+                                Need to exclude options warning because bootstrap
+                                classpath isn't set (on purpose).
+                                Need to exclude path warnings because Maven includes
+                                source directories that don't exist (e.g., generated-sources).
+                            -->
+			    <compilerArgs>
+				<arg>-Xlint</arg>
+				<arg>-Xlint:-options</arg>
+				<arg>-Xlint:-path</arg>
+				<!--
+				    Too many finalize warnings.
+				<arg>-Werror</arg>
+				-->
+			    </compilerArgs>
 			</configuration>
 		    </execution>
+                    <!--
+                        Exclude MailSessionDefinition and MailSessionDefinitions since
+                        the former requires JDK 1.8 and the latter depends on the former.
+                    -->
+                    <execution>
+                        <id>base-compile-7</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <skipMain>${mail.recompile.skip}</skipMain>
+                            <release>7</release>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                                <exclude>jakarta/mail/MailSessionDefinition.java</exclude>
+                                <exclude>jakarta/mail/MailSessionDefinitions.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
 		    <execution>
 			<id>default-testCompile</id>
 			<configuration>
-			    <source>1.7</source>
-			    <target>1.7</target>
+			    <release>8</release>
 			</configuration>
 		    </execution>
 		</executions>
@@ -501,9 +466,6 @@
 			    </Probe-Provider-XML-File-Names>
 			</manifestEntries>
 		    </archive>
-		    <excludes>
-			<exclude>**/*.java</exclude>
-		    </excludes>
 		</configuration>
 	    </plugin>
 
@@ -530,10 +492,10 @@
 			<configuration>
 			    <sources>
 				<source> <!-- for dependencies -->
-				    ${project.build.directory}/sources
+				    ${project.build.directory}/generated-sources/sources
 				</source>
 				<source> <!-- for Version.java -->
-				    target/classes
+				    ${project.build.directory}/generated-sources/version
 				</source>
 			    </sources>
 			</configuration>
@@ -554,6 +516,12 @@
 					<include>NOTICE.md</include>
 				    </includes>
 				</resource>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/sources</directory>
+                                    <excludes>
+                                        <exclude>**/*.java</exclude>
+                                    </excludes>
+                                </resource>
 			    </resources>
 			</configuration>
 		    </execution>
@@ -599,17 +567,6 @@
 			</goals>
 		    </execution>
 		</executions>
-		<configuration>
-		    <includePom>true</includePom>
-		    <!--
-			Since we added the classes directory using the
-			build-helper-maven-plugin above, we need to exclude
-			the class files from the source jar file.
-		    -->
-		    <excludes>
-			<exclude>**/*.class</exclude>
-		    </excludes>
-		</configuration>
 	    </plugin>
 
 <!-- not used
@@ -624,6 +581,11 @@
 
 	<pluginManagement>
 	    <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-compiler-plugin</artifactId>
@@ -637,17 +599,17 @@
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-jar-plugin</artifactId>
-		    <version>3.1.2</version>
+		    <version>3.2.0</version>
 		</plugin>
 		<plugin>
 		    <groupId>org.codehaus.mojo</groupId>
 		    <artifactId>build-helper-maven-plugin</artifactId>
-		    <version>1.7</version>
+		    <version>3.2.0</version>
 		</plugin>
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-assembly-plugin</artifactId>
-		    <version>2.4</version>
+		    <version>3.3.0</version>
 		</plugin>
 		<plugin>
 		    <!--
@@ -670,42 +632,46 @@
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-enforcer-plugin</artifactId>
-		    <version>3.0.0-M1</version>
+		    <version>3.0.0-M3</version>
 		</plugin>
 		<plugin>
 		    <groupId>org.apache.felix</groupId>
 		    <artifactId>maven-bundle-plugin</artifactId>
-		    <version>4.2.1</version>
+		    <version>5.1.1</version>
 		</plugin>
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-source-plugin</artifactId>
-		    <version>2.1.2</version>
+		    <version>3.2.1</version>
 		</plugin>
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-javadoc-plugin</artifactId>
 		    <version>3.2.0</version>
 		    <configuration>
-                        <source>8</source>
+                        <source>11</source>
 			<doclint>none</doclint>
                         <detectJavaApiLink>false</detectJavaApiLink>
-			<sourceFileExcludes>
-			    <sourceFileExclude>
-				module-info.java
-			    </sourceFileExclude>
-			</sourceFileExcludes>
+                        <docfilessubdirs>true</docfilessubdirs>
+                        <javadocDirectory>src/main/java</javadocDirectory>
+                        <quiet>true</quiet>
+                        <header>${mail.javadoc.impl.header}</header>
 		    </configuration>
 		</plugin>
+                <plugin>
+                    <groupId>org.commonjava.maven.plugins</groupId>
+                    <artifactId>directory-maven-plugin</artifactId>
+                    <version>0.3.1</version>
+                </plugin>
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-war-plugin</artifactId>
-		    <version>2.2</version>
+		    <version>3.3.1</version>
 		</plugin>
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-project-info-reports-plugin</artifactId>
-		    <version>2.7</version>
+		    <version>3.1.1</version>
 		</plugin>
 		<plugin>
 		    <groupId>org.glassfish.copyright</groupId>
@@ -719,7 +685,19 @@
 			</excludeFile>
 		    </configuration>
 		</plugin>
-	    </plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.ant</groupId>
+                            <artifactId>ant</artifactId>
+                            <version>1.10.9</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
 	</pluginManagement>
     </build>
 
@@ -775,6 +753,11 @@
 		<artifactId>jakarta.servlet.jsp-api</artifactId>
 		<version>3.0.0</version>
 	    </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.1</version>
+            </dependency>
 	</dependencies>
     </dependencyManagement>
 

--- a/pop3/src/main/java/module-info.java
+++ b/pop3/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,5 @@ module com.sun.mail.pop3 {
     provides jakarta.mail.Provider with
 	com.sun.mail.pop3.POP3Provider, com.sun.mail.pop3.POP3SSLProvider;
 
-    requires jakarta.mail;
-    requires java.logging;
-    requires java.security.sasl;
+    requires transitive jakarta.mail;
 }

--- a/publish/pom.xml
+++ b/publish/pom.xml
@@ -65,7 +65,6 @@
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
-	    <version>2.0.1-SNAPSHOT</version>
         </dependency>
     <!--
         <dependency>

--- a/smtp/src/main/java/module-info.java
+++ b/smtp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,5 @@ module com.sun.mail.smtp {
     provides jakarta.mail.Provider with
 	com.sun.mail.smtp.SMTPProvider, com.sun.mail.smtp.SMTPSSLProvider;
 
-    requires jakarta.mail;
-    requires java.logging;
-    requires java.security.sasl;
+    requires transitive jakarta.mail;
 }


### PR DESCRIPTION
-update build plugins (allows building on Java SE 15),
-resurrect building temporarily excluded parts (#473),
-fix content of provider implementation files (#493)
-define missing JPMS descriptors and fix existing ones,
  move away from Automatic-Module-Name in manifests
-include JPMS descriptors in final jar filess

fixes #473
fixes #493 