### PR TITLE
Android SocketChannel workaround not working around (backport)

### DIFF
--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -24,6 +24,7 @@ longer available.
 		  ----------------------------
 The following bugs have been fixed in the 1.6.6 release.
 
+E  403	Android SocketChannel workaround not working around
 E  464	use EPL v2 licensed dependencies
 E  456	MimeMessage.setFrom(null) fails instead of removing the header
 E  473	Several modules are not included in build when JDK11 is used

--- a/mail/src/main/java/com/sun/mail/iap/Protocol.java
+++ b/mail/src/main/java/com/sun/mail/iap/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/mail/src/main/java/com/sun/mail/iap/Protocol.java
+++ b/mail/src/main/java/com/sun/mail/iap/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,7 +30,6 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 
 import com.sun.mail.util.PropUtil;
@@ -536,21 +535,61 @@ public class Protocol {
     public SocketChannel getChannel() {
 	SocketChannel ret = socket.getChannel();
 	if (ret != null)
-	    return ret;
+		return ret;
 
-	// XXX - Android is broken and SSL wrapped sockets don't delegate
-	// the getChannel method to the wrapped Socket
 	if (socket instanceof SSLSocket) {
-	    try {
-		Field f = socket.getClass().getDeclaredField("socket");
-		f.setAccessible(true);
-		Socket s = (Socket)f.get(socket);
-		ret = s.getChannel();
-	    } catch (Exception ex) {
-		// ignore anything that might go wrong
-	    }
+		ret = Protocol.findSocketChannel(socket);
 	}
 	return ret;
+    }
+
+    /**
+     * Android is broken and SSL wrapped sockets don't delegate
+     * the getChannel method to the wrapped Socket.
+     * 
+     * @param socket a non null socket
+     * @return the SocketChannel or null if not found
+     */
+    private static SocketChannel findSocketChannel(Socket socket) {
+	//Search class hierarchy for field name socket regardless of modifier.
+	for (Class<?> k = socket.getClass(); k != Object.class; k = k.getSuperclass()) {
+		try {
+			Field f = k.getDeclaredField("socket");
+			f.setAccessible(true);
+			Socket s = (Socket) f.get(socket);
+			SocketChannel ret = s.getChannel();
+			if (ret != null) {
+				return ret;
+			}
+		} catch (Exception ignore) {
+			//ignore anything that might go wrong
+		}
+	}
+	
+	//Search class hierarchy for fields that can hold a Socket
+	//or subclass regardless of modifier.  Fields declared as super types of Socket
+	//will be ignored.
+	for (Class<?> k = socket.getClass(); k != Object.class; k = k.getSuperclass()) {
+		try {
+			for (Field f : k.getDeclaredFields()) {
+				if (Socket.class.isAssignableFrom(f.getType())) {
+					try {
+						f.setAccessible(true);
+						Socket s = (Socket) f.get(socket);
+						SocketChannel ret = s.getChannel();
+						if (ret != null) {
+							return ret;
+						}
+					} catch (Exception ignore) {
+						//ignore anything that might go wrong
+					}
+				}
+			}
+		} catch (Exception ignore) {
+			//ignore anything that might go wrong
+		}
+	}
+	return null;
     }
 
     /**

--- a/mail/src/test/java/com/sun/mail/iap/ProtocolTest.java
+++ b/mail/src/test/java/com/sun/mail/iap/ProtocolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/mail/src/test/java/com/sun/mail/iap/ProtocolTest.java
+++ b/mail/src/test/java/com/sun/mail/iap/ProtocolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,12 +17,17 @@
 package com.sun.mail.iap;
 
 import java.io.*;
+import java.lang.reflect.Method;
+import java.net.Socket;
+import java.nio.channels.SocketChannel;
 import java.util.Properties;
 
 import com.sun.mail.test.NullOutputStream;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test the Protocol class.
@@ -81,5 +86,202 @@ public final class ProtocolTest {
 	p = new Protocol(nullis, nullps, props, false);
 	tag = p.writeCommand("CMD", null);
 	assertEquals("A0", tag);
+    }
+
+    @Test
+    public void testLayer1Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer1of5()) {
+            findSocketChannel(s);
+            assertTrue(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testLayer2Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer2of5()) {
+            findSocketChannel(s);
+            assertTrue(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testLayer3Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer3of5()) {
+            findSocketChannel(s);
+            assertTrue(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testLayer4Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer4of5()) {
+            findSocketChannel(s);
+            assertTrue(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testLayer5Socket() throws IOException, ProtocolException {
+        try (LayerAbstractSocket s = new Layer5of5()) {
+            findSocketChannel(s);
+            assertTrue(s.foundChannel());
+        }
+    }
+    
+    
+    @Test
+    public void testRenamed1Socket() throws IOException, ProtocolException {
+        try (RenamedAbstractSocket s = new RenamedSocketLayer1of3()) {
+            findSocketChannel(s);
+            assertTrue(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testRenamed2Socket() throws IOException, ProtocolException {
+        try (RenamedAbstractSocket s = new RenamedSocketLayer2of3()) {
+            findSocketChannel(s);
+            assertTrue(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testRenamed3Socket() throws IOException, ProtocolException {
+        try (RenamedAbstractSocket s = new RenamedSocketLayer3of3()) {
+            findSocketChannel(s);
+            assertTrue(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testNullSocketsRenamed() throws IOException, ProtocolException {
+        try (RenamedAbstractSocket s = new NullSocketsRenamedSocket()) {
+            findSocketChannel(s);
+            assertTrue(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testHidden1Socket() throws IOException, ProtocolException {
+        try (HiddenAbstractSocket s = new HiddenSocket1of2()) {
+            //This could be implemented to find the socket. 
+            //However, we would have fetch field value to inspect the object.
+            //Most reads will not be what we are looking for so best to give up.
+            //Feel free to change the policy later if needed.
+            findSocketChannel(s);
+            assertFalse(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testHidden2Socket() throws IOException, ProtocolException {
+        try (HiddenAbstractSocket s = new HiddenSocket2of2()) {
+            //This could be implemented to find the socket. 
+            //However, we would have fetch field value to inspect the object.
+            //Most reads will not be what we are looking for so best to give up.
+            //Feel free to change the policy later if needed.
+            findSocketChannel(s);
+            assertFalse(s.foundChannel());
+        }
+    }
+    
+    @Test
+    public void testNamedNullAndHiddenSocket() throws IOException, ProtocolException {
+        try (HiddenAbstractSocket s = new NamedNullAndHiddenSocket()) {
+            findSocketChannel(s);
+            assertFalse(s.foundChannel());
+        }
+    }
+    
+    private SocketChannel findSocketChannel(Socket s) throws IOException {
+        try {
+	    Method m = Protocol.class.getDeclaredMethod("findSocketChannel", Socket.class);
+	    m.setAccessible(true);
+	    return (SocketChannel) m.invoke((Object) null, s);
+	} catch (RuntimeException re) {
+	    throw re;
+	} catch (Exception e) {
+	    throw new IOException(e);
+	}
+    }
+    
+    private static class RenamedSocketLayer3of3 extends RenamedSocketLayer1of3 {
+    }
+    
+    private static class RenamedSocketLayer2of3 extends RenamedSocketLayer1of3 {
+    }
+    
+    private static class RenamedSocketLayer1of3 extends RenamedAbstractSocket {    
+    }
+    
+    private static abstract class RenamedAbstractSocket extends Socket {
+        private Socket tekcos = new WrappedSocket();
+        
+        public boolean foundChannel() {
+            return WrappedSocket.foundChannel(tekcos);
+        }
+    }
+    
+    private static class NullSocketsRenamedSocket extends RenamedAbstractSocket {
+        @SuppressWarnings("unused") //Reflective access
+	private Socket socket;
+        @SuppressWarnings("unused") //Reflective access
+	private Socket tekcos;
+        
+    }
+    
+    private static class Layer5of5 extends Layer4of5 {
+    }
+    private static class Layer4of5 extends Layer3of5 {
+    }
+    private static class Layer3of5 extends Layer2of5 {
+    }
+    private static class Layer2of5 extends Layer1of5 {
+    }
+    private static class Layer1of5 extends LayerAbstractSocket {
+    }
+    
+    private static abstract class LayerAbstractSocket extends Socket {
+        private final Socket socket = new WrappedSocket();
+        
+        public boolean foundChannel() {
+            return WrappedSocket.foundChannel(socket);
+        }
+    }
+    
+    
+    private static class HiddenSocket2of2 extends HiddenSocket1of2 {
+    }
+    
+    private static class HiddenSocket1of2 extends HiddenAbstractSocket {
+    }
+    
+    private static abstract class HiddenAbstractSocket extends Socket {
+        private final Object hidden = new WrappedSocket();
+        
+        public boolean foundChannel() {
+            return WrappedSocket.foundChannel(hidden);
+        }
+    }
+    
+    private static class NamedNullAndHiddenSocket extends HiddenAbstractSocket {
+    
+        @SuppressWarnings("unused") //Reflective access
+        private Socket socket;
+    }
+    
+    private static class WrappedSocket extends Socket {
+        private boolean found;
+        
+        public static boolean foundChannel(Object ws) {
+            return ws instanceof WrappedSocket
+                  && ((WrappedSocket) ws).found;
+        }
+        
+        @Override
+        public SocketChannel getChannel() {
+            found = true;
+            return null;
+        }
     }
 }


### PR DESCRIPTION
@lukasj This is a backport of https://github.com/eclipse-ee4j/mail/issues/403
I cherry-picked the commits across from 2X branch and corrected the merge conflicts.  You should be able to squash merge this into the v1.x branch.  Let me know if I need to create a new issue for the backport.
