### PR TITLE
Improve code coverage in logging-mailhandler tests #512

### DIFF
--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -30,6 +30,7 @@ E  461	OAuth2 POP3 Support for Microsoft
 E  473	Several modules are not included in build when JDK11 is used
 E  493	javamail.providers file missing from provider jars after 1.6.5
 E  505	WriteTimeoutSocket::getFileDescriptor$ support for Conscrypt
+E  512	Improve code coverage in logging-mailhandler tests
 
 
 		  CHANGES IN THE 2.0.0 RELEASE

--- a/mail/src/test/java/com/sun/mail/util/logging/DurationFilterTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/DurationFilterTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2018 Jason Mehrens. All rights reserved.
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021 Jason Mehrens. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package com.sun.mail.util.logging;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.logging.*;
 import org.junit.*;
@@ -494,6 +495,8 @@ public class DurationFilterTest extends AbstractLogging {
     public void testEquals() {
         DurationFilter one = new DurationFilter();
         DurationFilter two = new DurationFilter();
+        assertFalse(one.equals((Object) null));
+        assertFalse(two.equals((Object) null));
         assertTrue(one.equals(one));
         assertTrue(two.equals(two));
         assertTrue(one.equals(two));
@@ -505,8 +508,45 @@ public class DurationFilterTest extends AbstractLogging {
         assertTrue(two.equals(two));
         assertFalse(one.equals(two));
         assertFalse(two.equals(one));
-        assertFalse(one.equals((Object) null));
-        assertFalse(two.equals((Object) null));
+
+        assertTrue(two.isLoggable(r));
+        assertTrue(two.equals(two));
+        assertTrue(one.equals(two));
+        assertTrue(two.equals(one));
+
+        assertTrue(two.isLoggable(r));
+        assertTrue(one.equals(one));
+        assertTrue(two.equals(two));
+        assertFalse(one.equals(two));
+        assertFalse(two.equals(one));
+
+
+        final long then = r.getMillis();
+        one = new DurationFilter();
+        two = new DurationFilter();
+        assertTrue(one.isLoggable(r));
+        setEpochMilli(r, then + 1);
+        assertTrue(one.isLoggable(r));
+        assertTrue(two.isLoggable(r));
+        setEpochMilli(r, then);
+        assertTrue(two.isLoggable(r));
+        assertFalse(one.equals(two));
+        assertFalse(two.equals(one));
+
+        one = new DurationFilter();
+        two = new DurationFilterExt();
+        assertFalse(one.equals(two));
+        assertFalse(two.equals(one));
+
+        one = new DurationFilter(1, 1);
+        two = new DurationFilter(2, 1);
+        assertFalse(one.equals(two));
+        assertFalse(two.equals(one));
+
+        one = new DurationFilter(1, 1);
+        two = new DurationFilter(1, 2);
+        assertFalse(one.equals(two));
+        assertFalse(two.equals(one));
     }
 
     @Test
@@ -601,6 +641,16 @@ public class DurationFilterTest extends AbstractLogging {
         testInitDuration("15*60*1000", 15L * 60L * 1000L);
         testInitDuration("15L * 60L * 1000L", 15L * 60L * 1000L);
         testInitDuration("15L*60L*1000L", 15L * 60L * 1000L);
+    }
+
+    @Test
+    public void testInitDurationPartExp() throws Exception {
+        testInitDuration("15*", 15L * 60L * 1000L);
+        testInitDuration("*15", 15L * 60L * 1000L);
+        testInitDuration("* 15", 15L * 60L * 1000L);
+        testInitDuration("15 *", 15L * 60L * 1000L);
+        testInitDuration(" * 15", 15L * 60L * 1000L);
+        testInitDuration("15 * ", 15L * 60L * 1000L);
     }
 
     @Test
@@ -706,6 +756,8 @@ public class DurationFilterTest extends AbstractLogging {
 
     private void testInitDuration(String d, long expect) throws Exception {
         testInit("duration", d, expect);
+        testInit("duration", d.toUpperCase(Locale.ENGLISH), expect);
+        testInit("duration", d.toLowerCase(Locale.ENGLISH), expect);
     }
 
     private void testInitRecords(String r, long expect) throws Exception {

--- a/mail/src/test/java/com/sun/mail/util/logging/SeverityComparatorTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/SeverityComparatorTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2018 Jason Mehrens. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Jason Mehrens. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -134,6 +134,71 @@ public class SeverityComparatorTest extends AbstractLogging {
         assertEquals(0, a.compareThrowable((Throwable) null, (Throwable) null));
         assertTrue(a.compareThrowable(new Throwable(), (Throwable) null) > 0);
         assertTrue(a.compareThrowable((Throwable) null, new Throwable()) < 0);
+    }
+
+    @Test
+    public void testCompareNormalNormal() {
+        SeverityComparator a = new SeverityComparator();
+        assertTrue(a.compareThrowable(new InterruptedException(), new InterruptedIOException()) == 0);
+        assertTrue(a.compareThrowable(new InterruptedIOException(), new InterruptedException()) == 0);
+        assertTrue(a.compareThrowable(new InterruptedException(), new Error()) < 0);
+
+    }
+
+    @Test
+    public void testCompareNormalError() {
+        SeverityComparator a = new SeverityComparator();
+        assertTrue(a.compareThrowable(new InterruptedException(), new Error()) < 0);
+        assertTrue(a.compareThrowable(new Error(), new InterruptedException()) > 0);
+    }
+
+    @Test
+    public void testCompareNormalRuntimeException() {
+        SeverityComparator a = new SeverityComparator();
+        assertTrue(a.compareThrowable(new InterruptedException(), new RuntimeException()) < 0);
+        assertTrue(a.compareThrowable(new RuntimeException(), new InterruptedException()) > 0);
+    }
+
+    @Test
+    public void testCompareNormalNonNormal() {
+        SeverityComparator a = new SeverityComparator();
+        assertTrue(a.compareThrowable(new InterruptedException(), new Throwable()) < 0);
+        assertTrue(a.compareThrowable(new Throwable(), new InterruptedException()) > 0);
+    }
+
+    @Test
+    public void testCompareRuntimeRuntime() {
+        SeverityComparator a = new SeverityComparator();
+        assertTrue(a.compareThrowable(new NullPointerException(), new IllegalArgumentException()) == 0);
+        assertTrue(a.compareThrowable(new IllegalArgumentException(), new NullPointerException()) == 0);
+    }
+
+    @Test
+    public void testCompareThrowableRuntime() {
+        SeverityComparator a = new SeverityComparator();
+        assertTrue(a.compareThrowable(new Throwable(), new IllegalArgumentException()) < 0);
+        assertTrue(a.compareThrowable(new IllegalArgumentException(), new Throwable()) > 0);
+    }
+
+    @Test
+    public void testCompareThrowableError() {
+        SeverityComparator a = new SeverityComparator();
+        assertTrue(a.compareThrowable(new Throwable(), new Error()) < 0);
+        assertTrue(a.compareThrowable(new Error(), new Throwable()) > 0);
+    }
+
+    @Test
+    public void testCompareRuntimeError() {
+        SeverityComparator a = new SeverityComparator();
+        assertTrue(a.compareThrowable(new RuntimeException(), new Error()) < 0);
+        assertTrue(a.compareThrowable(new Error(), new RuntimeException()) > 0);
+    }
+
+    @Test
+    public void testCompareThrowableException() {
+        SeverityComparator a = new SeverityComparator();
+        assertTrue(a.compareThrowable(new Throwable(), new Exception()) == 0);
+        assertTrue(a.compareThrowable(new Exception(), new Throwable()) == 0);
     }
 
     @Test
@@ -1078,10 +1143,10 @@ public class SeverityComparatorTest extends AbstractLogging {
 
         //NPE checks.
         assertNotNull(a);
-        assertFalse(a.equals(null));
+        assertFalse(a.equals((Object) null));
 
         assertNotNull(b);
-        assertFalse(b.equals(null));
+        assertFalse(b.equals((Object) null));
 
         //Reflexive test.
         assertTrue(a.equals(a));
@@ -1090,6 +1155,10 @@ public class SeverityComparatorTest extends AbstractLogging {
         //Transitive test.
         assertTrue(a.equals(b));
         assertTrue(b.equals(a));
+
+        SubSeverityComparator c = new SubSeverityComparator();
+        assertFalse(c.equals(a));
+        assertFalse(a.equals(c));
     }
 
     @Test
@@ -1299,6 +1368,12 @@ public class SeverityComparatorTest extends AbstractLogging {
 
     private Throwable headWitChain(Throwable last) {
         return new WorkInterruptionException().initCause(last);
+    }
+
+    private static class SubSeverityComparator extends SeverityComparator {
+        private static final long serialVersionUID = 1L;
+        SubSeverityComparator() {
+        }
     }
 
     /**


### PR DESCRIPTION
Pull request for issue: https://github.com/eclipse-ee4j/mail/issues/512

I'll backport this to 1x when this is approved.  The details are covered in the issue but the main reason to backport is to deal with finding an unknown host and depending on the network, the bad-host-name can be resolved.