### PR TITLE
Address reliance on default constructors #530

### DIFF
--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -20,6 +20,12 @@ Seven digit bug numbers are from the old Sun bug database, which is no
 longer available.
 
 
+		  CHANGES IN THE 2.0.2 RELEASE
+		  ----------------------------
+The following bugs have been fixed in the 2.0.2 release.
+E  530	Address reliance on default constructors
+
+
 		  CHANGES IN THE 2.0.1 RELEASE
 		  ----------------------------
 The following bugs have been fixed in the 2.0.1 release.
@@ -31,7 +37,6 @@ E  473	Several modules are not included in build when JDK11 is used
 E  493	javamail.providers file missing from provider jars after 1.6.5
 E  505	WriteTimeoutSocket::getFileDescriptor$ support for Conscrypt
 E  512	Improve code coverage in logging-mailhandler tests
-E  530	Address reliance on default constructors
 
 
 		  CHANGES IN THE 2.0.0 RELEASE

--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -31,6 +31,7 @@ E  473	Several modules are not included in build when JDK11 is used
 E  493	javamail.providers file missing from provider jars after 1.6.5
 E  505	WriteTimeoutSocket::getFileDescriptor$ support for Conscrypt
 E  512	Improve code coverage in logging-mailhandler tests
+E  530	Address reliance on default constructors
 
 
 		  CHANGES IN THE 2.0.0 RELEASE

--- a/dsn/src/main/java/com/sun/mail/dsn/message_deliverystatus.java
+++ b/dsn/src/main/java/com/sun/mail/dsn/message_deliverystatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,10 @@
 package com.sun.mail.dsn;
 
 import java.io.*;
-import java.util.Properties;
+//import java.util.Properties;
 import jakarta.activation.*;
 import jakarta.mail.*;
-import jakarta.mail.internet.*;
+//import jakarta.mail.internet.*;
 
 
 /**
@@ -34,8 +34,14 @@ public class message_deliverystatus implements DataContentHandler {
 
     ActivationDataFlavor ourDataFlavor = new ActivationDataFlavor(
 	DeliveryStatus.class,
-	"message/delivery-status", 
+	"message/delivery-status",
 	"Delivery Status");
+
+    /**
+     * Creates a default {@code message_deliverystatus}.
+     */
+    public message_deliverystatus() {
+    }
 
     /**
      * return the ActivationDataFlavors for this <code>DataContentHandler</code>
@@ -59,7 +65,7 @@ public class message_deliverystatus implements DataContentHandler {
 	else
 	    return null;
     }
-    
+
     /**
      * Return the content.
      */
@@ -88,16 +94,16 @@ public class message_deliverystatus implements DataContentHandler {
 		    me.toString());
 	}
     }
-    
+
     /**
      */
-    public void writeTo(Object obj, String mimeType, OutputStream os) 
+    public void writeTo(Object obj, String mimeType, OutputStream os)
 			throws IOException {
 	// if the object is a DeliveryStatus, we know how to write that out
 	if (obj instanceof DeliveryStatus) {
 	    DeliveryStatus ds = (DeliveryStatus)obj;
 	    ds.writeTo(os);
-	    
+
 	} else {
 	    throw new IOException("unsupported object");
 	}

--- a/dsn/src/main/java/com/sun/mail/dsn/message_dispositionnotification.java
+++ b/dsn/src/main/java/com/sun/mail/dsn/message_dispositionnotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,10 @@
 package com.sun.mail.dsn;
 
 import java.io.*;
-import java.util.Properties;
+//import java.util.Properties;
 import jakarta.activation.*;
 import jakarta.mail.*;
-import jakarta.mail.internet.*;
+//import jakarta.mail.internet.*;
 
 
 /**
@@ -34,8 +34,14 @@ public class message_dispositionnotification implements DataContentHandler {
 
     ActivationDataFlavor ourDataFlavor = new ActivationDataFlavor(
 	DispositionNotification.class,
-	"message/disposition-notification", 
+	"message/disposition-notification",
 	"Disposition Notification");
+
+    /**
+     * Creates a default {@code message_dispositionnotification}.
+     */
+    public message_dispositionnotification() {
+    }
 
     /**
      * return the ActivationDataFlavors for this <code>DataContentHandler</code>
@@ -59,7 +65,7 @@ public class message_dispositionnotification implements DataContentHandler {
 	else
 	    return null;
     }
-    
+
     /**
      * Return the content.
      */
@@ -89,10 +95,10 @@ public class message_dispositionnotification implements DataContentHandler {
 		    me.toString());
 	}
     }
-    
+
     /**
      */
-    public void writeTo(Object obj, String mimeType, OutputStream os) 
+    public void writeTo(Object obj, String mimeType, OutputStream os)
 			throws IOException {
 	// if it's a DispositionNotification, we know how to write that out
 	if (obj instanceof DispositionNotification) {

--- a/dsn/src/main/java/com/sun/mail/dsn/multipart_report.java
+++ b/dsn/src/main/java/com/sun/mail/dsn/multipart_report.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,6 @@ package com.sun.mail.dsn;
 import java.io.*;
 import jakarta.activation.*;
 import jakarta.mail.MessagingException;
-import jakarta.mail.internet.*;
 
 
 /**
@@ -32,8 +31,14 @@ import jakarta.mail.internet.*;
 public class multipart_report implements DataContentHandler {
     private ActivationDataFlavor myDF = new ActivationDataFlavor(
 	    MultipartReport.class,
-	    "multipart/report", 
+	    "multipart/report",
 	    "Multipart Report");
+
+    /**
+     * Creates a default {@code multipart_report}.
+     */
+    public multipart_report() {
+    }
 
     /**
      * Return the ActivationDataFlavors for this <code>DataContentHandler</code>.
@@ -60,13 +65,13 @@ public class multipart_report implements DataContentHandler {
 	else
 	    return null;
     }
-    
+
     /**
      * Return the content.
      */
     public Object getContent(DataSource ds) throws IOException {
 	try {
-	    return new MultipartReport(ds); 
+	    return new MultipartReport(ds);
 	} catch (MessagingException e) {
 	    IOException ioex =
 		new IOException("Exception while constructing MultipartReport");
@@ -74,11 +79,11 @@ public class multipart_report implements DataContentHandler {
 	    throw ioex;
 	}
     }
-    
+
     /**
      * Write the object to the output stream, using the specific MIME type.
      */
-    public void writeTo(Object obj, String mimeType, OutputStream os) 
+    public void writeTo(Object obj, String mimeType, OutputStream os)
 			throws IOException {
 	if (obj instanceof MultipartReport) {
 	    try {

--- a/dsn/src/main/java/com/sun/mail/dsn/text_rfc822headers.java
+++ b/dsn/src/main/java/com/sun/mail/dsn/text_rfc822headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,14 +30,20 @@ import jakarta.mail.internet.*;
  *
  */
 public class text_rfc822headers implements DataContentHandler {
-    private static ActivationDataFlavor myDF = new ActivationDataFlavor(
+    private static final ActivationDataFlavor myDF = new ActivationDataFlavor(
 	MessageHeaders.class,
 	"text/rfc822-headers",
 	"RFC822 headers");
-    private static ActivationDataFlavor myDFs = new ActivationDataFlavor(
+    private static final ActivationDataFlavor myDFs = new ActivationDataFlavor(
 	java.lang.String.class,
 	"text/rfc822-headers",
 	"RFC822 headers");
+
+    /**
+     * Creates a default {@code text_rfc822headers}.
+     */
+    public text_rfc822headers() {
+    }
 
     /**
      * Return the ActivationDataFlavors for this <code>DataContentHandler</code>.
@@ -55,7 +61,7 @@ public class text_rfc822headers implements DataContentHandler {
      * @param ds The DataSource corresponding to the data
      * @return String object
      */
-    public Object getTransferData(ActivationDataFlavor df, DataSource ds) 
+    public Object getTransferData(ActivationDataFlavor df, DataSource ds)
 			throws IOException {
 	// use myDF.equals to be sure to get ActivationDataFlavor.equals,
 	// which properly ignores Content-Type parameters in comparison
@@ -79,7 +85,7 @@ public class text_rfc822headers implements DataContentHandler {
     private Object getStringContent(DataSource ds) throws IOException {
 	String enc = null;
 	InputStreamReader is = null;
-	
+
 	try {
 	    enc = getCharset(ds.getContentType());
 	    is = new InputStreamReader(ds.getInputStream(), enc);
@@ -126,7 +132,7 @@ public class text_rfc822headers implements DataContentHandler {
     /**
      * Write the object to the output stream, using the specified MIME type.
      */
-    public void writeTo(Object obj, String type, OutputStream os) 
+    public void writeTo(Object obj, String type, OutputStream os)
 			throws IOException {
 	if (obj instanceof MessageHeaders) {
 	    MessageHeaders mh = (MessageHeaders)obj;

--- a/mail/src/main/java/com/sun/mail/auth/OAuth2SaslClientFactory.java
+++ b/mail/src/main/java/com/sun/mail/auth/OAuth2SaslClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,6 +39,14 @@ public class OAuth2SaslClientFactory implements SaslClientFactory {
 	    super(PROVIDER_NAME, 1.0, "XOAUTH2 SASL Mechanism");
 	    put(MECHANISM_NAME, OAuth2SaslClientFactory.class.getName());
 	}
+    }
+
+    /**
+     * Creates a default {@code OAuth2SaslClientFactory}.
+     *
+     * @see #init()
+     */
+    public OAuth2SaslClientFactory() {
     }
 
     @Override

--- a/mail/src/main/java/com/sun/mail/handlers/handler_base.java
+++ b/mail/src/main/java/com/sun/mail/handlers/handler_base.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,12 @@ import jakarta.activation.*;
  * Base class for other DataContentHandlers.
  */
 public abstract class handler_base implements DataContentHandler {
+
+    /**
+     * Creates a default {@code handler_base}.
+     */
+    public handler_base() {
+    }
 
     /**
      * Return an array of ActivationDataFlavors that we support.
@@ -70,7 +76,7 @@ public abstract class handler_base implements DataContentHandler {
      * @exception	IOException	for errors reading the data
      */
     @Override
-    public Object getTransferData(ActivationDataFlavor df, DataSource ds) 
+    public Object getTransferData(ActivationDataFlavor df, DataSource ds)
 			throws IOException {
 	ActivationDataFlavor[] adf = getDataFlavors();
 	for (int i = 0; i < adf.length; i++) {

--- a/mail/src/main/java/com/sun/mail/handlers/image_gif.java
+++ b/mail/src/main/java/com/sun/mail/handlers/image_gif.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,6 +27,12 @@ public class image_gif extends handler_base {
     private static ActivationDataFlavor[] myDF = {
 	new ActivationDataFlavor(Image.class, "image/gif", "GIF Image")
     };
+
+    /**
+     * Creates a default {@code image_gif}.
+     */
+    public image_gif() {
+    }
 
     @Override
     protected ActivationDataFlavor[] getDataFlavors() {

--- a/mail/src/main/java/com/sun/mail/handlers/image_jpeg.java
+++ b/mail/src/main/java/com/sun/mail/handlers/image_jpeg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,12 @@ public class image_jpeg extends image_gif {
     private static ActivationDataFlavor[] myDF = {
 	new ActivationDataFlavor(Image.class, "image/jpeg", "JPEG Image")
     };
+
+    /**
+     * Creates a default {@code image_jpeg}.
+     */
+    public image_jpeg() {
+    }
 
     @Override
     protected ActivationDataFlavor[] getDataFlavors() {

--- a/mail/src/main/java/com/sun/mail/handlers/message_rfc822.java
+++ b/mail/src/main/java/com/sun/mail/handlers/message_rfc822.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,6 +34,12 @@ public class message_rfc822 extends handler_base {
 	new ActivationDataFlavor(Message.class, "message/rfc822", "Message")
     };
 
+    /**
+     * Creates a default {@code message_rfc822}.
+     */
+    public message_rfc822() {
+    }
+
     @Override
     protected ActivationDataFlavor[] getDataFlavors() {
 	return ourDataFlavor;
@@ -66,12 +72,12 @@ public class message_rfc822 extends handler_base {
 	    throw ioex;
 	}
     }
-    
+
     /**
      * Write the object as a byte stream.
      */
     @Override
-    public void writeTo(Object obj, String mimeType, OutputStream os) 
+    public void writeTo(Object obj, String mimeType, OutputStream os)
 			throws IOException {
 	if (!(obj instanceof Message))
 	    throw new IOException("\"" + getDataFlavors()[0].getMimeType() +

--- a/mail/src/main/java/com/sun/mail/handlers/multipart_mixed.java
+++ b/mail/src/main/java/com/sun/mail/handlers/multipart_mixed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,6 +29,12 @@ public class multipart_mixed extends handler_base {
 				    "multipart/mixed", "Multipart")
     };
 
+    /**
+     * Creates a default {@code multipart_mixed}.
+     */
+    public multipart_mixed() {
+    }
+
     @Override
     protected ActivationDataFlavor[] getDataFlavors() {
 	return myDF;
@@ -40,7 +46,7 @@ public class multipart_mixed extends handler_base {
     @Override
     public Object getContent(DataSource ds) throws IOException {
 	try {
-	    return new MimeMultipart(ds); 
+	    return new MimeMultipart(ds);
 	} catch (MessagingException e) {
 	    IOException ioex =
 		new IOException("Exception while constructing MimeMultipart");
@@ -48,12 +54,12 @@ public class multipart_mixed extends handler_base {
 	    throw ioex;
 	}
     }
-    
+
     /**
      * Write the object to the output stream, using the specific MIME type.
      */
     @Override
-    public void writeTo(Object obj, String mimeType, OutputStream os) 
+    public void writeTo(Object obj, String mimeType, OutputStream os)
 			throws IOException {
 	if (!(obj instanceof Multipart))
 	    throw new IOException("\"" + getDataFlavors()[0].getMimeType() +

--- a/mail/src/main/java/com/sun/mail/handlers/text_html.java
+++ b/mail/src/main/java/com/sun/mail/handlers/text_html.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,12 @@ public class text_html extends text_plain {
     private static ActivationDataFlavor[] myDF = {
 	new ActivationDataFlavor(String.class, "text/html", "HTML String")
     };
+
+    /**
+     * Creates a default {@code text_html}.
+     */
+    public text_html() {
+    }
 
     @Override
     protected ActivationDataFlavor[] getDataFlavors() {

--- a/mail/src/main/java/com/sun/mail/handlers/text_plain.java
+++ b/mail/src/main/java/com/sun/mail/handlers/text_plain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,10 +31,16 @@ public class text_plain extends handler_base {
     };
 
     /**
+     * Creates a default {@code text_plain}.
+     */
+    public text_plain() {
+    }
+
+    /**
      * An OuputStream wrapper that doesn't close the underlying stream.
      */
     private static class NoCloseOutputStream extends FilterOutputStream {
-	public NoCloseOutputStream(OutputStream os) {
+	NoCloseOutputStream(OutputStream os) {
 	    super(os);
 	}
 
@@ -53,7 +59,7 @@ public class text_plain extends handler_base {
     public Object getContent(DataSource ds) throws IOException {
 	String enc = null;
 	InputStreamReader is = null;
-	
+
 	try {
 	    enc = getCharset(ds.getContentType());
 	    is = new InputStreamReader(ds.getInputStream(), enc);
@@ -96,12 +102,12 @@ public class text_plain extends handler_base {
 	    }
 	}
     }
-    
+
     /**
      * Write the object to the output stream, using the specified MIME type.
      */
     @Override
-    public void writeTo(Object obj, String type, OutputStream os) 
+    public void writeTo(Object obj, String type, OutputStream os)
 			throws IOException {
 	if (!(obj instanceof String))
 	    throw new IOException("\"" + getDataFlavors()[0].getMimeType() +

--- a/mail/src/main/java/com/sun/mail/handlers/text_xml.java
+++ b/mail/src/main/java/com/sun/mail/handlers/text_xml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,6 +44,12 @@ public class text_xml extends text_plain {
 	new ActivationDataFlavor(StreamSource.class, "text/xml", "XML"),
 	new ActivationDataFlavor(StreamSource.class, "application/xml", "XML")
     };
+
+    /**
+     * Creates a default {@code text_xml}.
+     */
+    public text_xml() {
+    }
 
     @Override
     protected ActivationDataFlavor[] getDataFlavors() {

--- a/mail/src/main/java/com/sun/mail/imap/protocol/BASE64MailboxDecoder.java
+++ b/mail/src/main/java/com/sun/mail/imap/protocol/BASE64MailboxDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,7 +28,18 @@ import java.text.CharacterIterator;
  */
 
 public class BASE64MailboxDecoder {
-    
+
+    /**
+     * Creates a default {@code BASE64MailboxDecoder}.
+     * This constructor should never be invoked.
+     *
+     * @deprecated This is static utility class.
+     */
+    @Deprecated()
+    public BASE64MailboxDecoder() {
+        //TODO: Made private and hostile.
+    }
+
     public static String decode(String original) {
 	if (original == null || original.length() == 0)
 	    return original;
@@ -36,10 +47,10 @@ public class BASE64MailboxDecoder {
 	boolean changedString = false;
 	int copyTo = 0;
 	// it will always be less than the original
-	char[] chars = new char[original.length()]; 
+	char[] chars = new char[original.length()];
 	StringCharacterIterator iter = new StringCharacterIterator(original);
-	
-	for(char c = iter.first(); c != CharacterIterator.DONE; 
+
+	for(char c = iter.first(); c != CharacterIterator.DONE;
 	    c = iter.next()) {
 
 	    if (c == '&') {
@@ -49,13 +60,13 @@ public class BASE64MailboxDecoder {
 		chars[copyTo++] = c;
 	    }
 	}
-	
+
 	// now create our string from the char array
 	if (changedString) {
 	    return new String(chars, 0, copyTo);
 	} else {
 	    return original;
-	}	
+	}
     }
 
 
@@ -77,12 +88,12 @@ public class BASE64MailboxDecoder {
 		break;
 	    }
 	    firsttime = false;
-	    
+
 	    // next byte
-	    byte orig_1 = (byte) iter.next();	    
+	    byte orig_1 = (byte) iter.next();
 	    if (orig_1 == -1 || orig_1 == '-')
 		break; // no more chars, invalid base64
-	    
+
 	    byte a, b, current;
 	    a = pem_convert_array[orig_0 & 0xff];
 	    b = pem_convert_array[orig_1 & 0xff];
@@ -96,14 +107,14 @@ public class BASE64MailboxDecoder {
 	    } else {
 		leftover = current & 0xff;
 	    }
-	    
+
 	    byte orig_2 = (byte) iter.next();
 	    if (orig_2 == '=') { // End of this BASE64 encoding
 		continue;
 	    } else if (orig_2 == -1 || orig_2 == '-') {
 	    	break; // no more chars
 	    }
-	    	    
+
 	    // second decoded byte
 	    a = b;
 	    b = pem_convert_array[orig_2 & 0xff];
@@ -123,21 +134,21 @@ public class BASE64MailboxDecoder {
 	    } else if (orig_3 == -1 || orig_3 == '-') {
 	    	break;  // no more chars
 	    }
-	    
+
 	    // The third decoded byte
 	    a = b;
 	    b = pem_convert_array[orig_3 & 0xff];
 	    current = (byte)(((a << 6) & 0xc0) | (b & 0x3f));
-	    
+
 	    // use the leftover to create a Unicode Character (2 bytes)
 	    if (leftover != -1) {
 		buffer[offset++] = (char)(leftover << 8 | (current & 0xff));
 		leftover = -1;
 	    } else {
 		leftover = current & 0xff;
-	    }	    
+	    }
 	}
-	
+
 	return offset;
     }
 
@@ -145,7 +156,7 @@ public class BASE64MailboxDecoder {
      * This character array provides the character to value map
      * based on RFC1521, but with the modification from RFC2060
      * which changes the '/' to a ','.
-     */  
+     */
 
     // shared with BASE64MailboxEncoder
     static final char pem_array[] = {
@@ -166,5 +177,5 @@ public class BASE64MailboxDecoder {
 	    pem_convert_array[i] = -1;
 	for(int i = 0; i < pem_array.length; i++)
 	    pem_convert_array[pem_array[i]] = (byte) i;
-    }    
+    }
 }

--- a/mail/src/main/java/com/sun/mail/imap/protocol/BASE64MailboxDecoder.java
+++ b/mail/src/main/java/com/sun/mail/imap/protocol/BASE64MailboxDecoder.java
@@ -35,7 +35,7 @@ public class BASE64MailboxDecoder {
      *
      * @deprecated This is static utility class.
      */
-    @Deprecated()
+    @Deprecated
     public BASE64MailboxDecoder() {
         //TODO: Made private and hostile.
     }

--- a/mail/src/main/java/com/sun/mail/util/logging/SeverityComparator.java
+++ b/mail/src/main/java/com/sun/mail/util/logging/SeverityComparator.java
@@ -95,8 +95,8 @@ public class SeverityComparator implements Comparator<LogRecord>, Serializable {
      * Creates a default {@code SeverityComparator}.
      */
     public SeverityComparator() {
-        //readResolve() is not implemented incase the comparator
-    	//is the target of a synchronized block.
+        //readResolve() is not implemented in case the comparator
+        //is the target of a synchronized block.
     }
 
     /**

--- a/mail/src/main/java/com/sun/mail/util/logging/SeverityComparator.java
+++ b/mail/src/main/java/com/sun/mail/util/logging/SeverityComparator.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2018 Jason Mehrens. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Jason Mehrens. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,6 +92,14 @@ public class SeverityComparator implements Comparator<LogRecord>, Serializable {
     }
 
     /**
+     * Creates a default {@code SeverityComparator}.
+     */
+    public SeverityComparator() {
+        //readResolve() is not implemented encause comparator is the target
+        //of a synchronized block.
+    }
+
+    /**
      * Identifies a single throwable that best describes the given throwable and
      * the entire {@linkplain Throwable#getCause() cause} chain. This method can
      * be overridden to change the behavior of
@@ -111,12 +119,12 @@ public class SeverityComparator implements Comparator<LogRecord>, Serializable {
         for (Throwable cause = chain; cause != null; cause = cause.getCause()) {
             root = cause;  //Find the deepest cause.
 
-            //Find the deepest nomral occurrance.
+            //Find the deepest normal occurrance.
             if (isNormal(cause)) {
                 normal = cause;
             }
 
-            //Find the deepest error that happened before a normal occurance.
+            //Find the deepest error that happened before a normal occurrance.
             if (normal == null && cause instanceof Error) {
                 high = cause;
             }

--- a/mail/src/main/java/com/sun/mail/util/logging/SeverityComparator.java
+++ b/mail/src/main/java/com/sun/mail/util/logging/SeverityComparator.java
@@ -95,8 +95,8 @@ public class SeverityComparator implements Comparator<LogRecord>, Serializable {
      * Creates a default {@code SeverityComparator}.
      */
     public SeverityComparator() {
-        //readResolve() is not implemented encause comparator is the target
-        //of a synchronized block.
+        //readResolve() is not implemented incase the comparator
+    	//is the target of a synchronized block.
     }
 
     /**

--- a/mail/src/main/java/jakarta/mail/Address.java
+++ b/mail/src/main/java/jakarta/mail/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,6 +32,12 @@ import java.io.Serializable;
 public abstract class Address implements Serializable {
 
     private static final long serialVersionUID = -5822459626751992278L;
+
+    /**
+     * Creates a default {@code Address}.
+     */
+    public Address() {
+    }
 
     /**
      * Return a type string that identifies this address type.

--- a/mail/src/main/java/jakarta/mail/Authenticator.java
+++ b/mail/src/main/java/jakarta/mail/Authenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,9 +45,6 @@ import java.net.InetAddress;
  * @author  Bill Foote
  * @author  Bill Shannon
  */
-
-// There are no abstract methods, but to be useful the user must
-// subclass.
 public abstract class Authenticator {
 
     private InetAddress requestingSite;
@@ -55,6 +52,15 @@ public abstract class Authenticator {
     private String requestingProtocol;
     private String requestingPrompt;
     private String requestingUserName;
+
+    /**
+     * Creates a default {@code Authenticator}.
+     * There are no abstract methods, but to be useful the user must subclass.
+     *
+     * @see #getPasswordAuthentication()
+     */
+    public Authenticator() {
+    }
 
     /**
      * Ask the authenticator for a password.

--- a/mail/src/main/java/jakarta/mail/BodyPart.java
+++ b/mail/src/main/java/jakarta/mail/BodyPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,6 +35,12 @@ public abstract class BodyPart implements Part {
      * @since	JavaMail 1.1
      */
     protected Multipart parent;
+
+    /**
+     * Creates a default {@code BodyPart}.
+     */
+    public BodyPart() {
+    }
 
     /**
      * Return the containing <code>Multipart</code> object,

--- a/mail/src/main/java/jakarta/mail/event/ConnectionAdapter.java
+++ b/mail/src/main/java/jakarta/mail/event/ConnectionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,14 @@ package jakarta.mail.event;
  * @author John Mani
  */
 public abstract class ConnectionAdapter implements ConnectionListener {
+
+
+    /**
+     * Creates a default {@code ConnectionAdapter}.
+     */
+    public ConnectionAdapter() {
+    }
+
     @Override
     public void opened(ConnectionEvent e) {}
     @Override

--- a/mail/src/main/java/jakarta/mail/event/FolderAdapter.java
+++ b/mail/src/main/java/jakarta/mail/event/FolderAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,13 @@ package jakarta.mail.event;
  * @author John Mani
  */
 public abstract class FolderAdapter implements FolderListener {
+
+    /**
+     * Creates a default {@code FolderAdapter}.
+     */
+    public FolderAdapter() {
+    }
+
     @Override
     public void folderCreated(FolderEvent e) {}
     @Override

--- a/mail/src/main/java/jakarta/mail/event/MessageCountAdapter.java
+++ b/mail/src/main/java/jakarta/mail/event/MessageCountAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,13 @@ package jakarta.mail.event;
  * @author John Mani
  */
 public abstract class MessageCountAdapter implements MessageCountListener {
+
+    /**
+     * Creates a default {@code MessageCountAdapter}.
+     */
+    public MessageCountAdapter() {
+    }
+
     @Override
     public void messagesAdded(MessageCountEvent e) {}
     @Override

--- a/mail/src/main/java/jakarta/mail/event/TransportAdapter.java
+++ b/mail/src/main/java/jakarta/mail/event/TransportAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,13 @@ package jakarta.mail.event;
  * @author John Mani
  */
 public abstract class TransportAdapter implements TransportListener {
+
+    /**
+     * Creates a default {@code TransportAdapter}.
+     */
+    public TransportAdapter() {
+    }
+
     @Override
     public void messageDelivered(TransportEvent e) {}
     @Override

--- a/mail/src/main/java/jakarta/mail/search/ComparisonTerm.java
+++ b/mail/src/main/java/jakarta/mail/search/ComparisonTerm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,8 @@ package jakarta.mail.search;
  * @author John Mani
  */
 public abstract class ComparisonTerm extends SearchTerm {
+    private static final long serialVersionUID = 1456646953666474308L;
+
     public static final int LE = 1;
     public static final int LT = 2;
     public static final int EQ = 3;
@@ -38,7 +40,13 @@ public abstract class ComparisonTerm extends SearchTerm {
      */
     protected int comparison;
 
-    private static final long serialVersionUID = 1456646953666474308L;
+    /**
+     * Creates a default {@code ComparisonTerm}.
+     *
+     * @see #comparison
+     */
+    public ComparisonTerm() {
+    }
 
     /**
      * Equality comparison.

--- a/mail/src/main/java/jakarta/mail/search/SearchTerm.java
+++ b/mail/src/main/java/jakarta/mail/search/SearchTerm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,6 +41,12 @@ import jakarta.mail.Message;
 public abstract class SearchTerm implements Serializable {
 
     private static final long serialVersionUID = -6652358452205992789L;
+
+    /**
+     * Creates a default {@code SearchTerm}.
+     */
+    public SearchTerm() {
+    }
 
     /**
      * This method applies a specific match criterion to the given

--- a/mail/src/test/java/com/sun/mail/util/logging/CollectorFormatterTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/CollectorFormatterTest.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.text.DateFormat;
 import java.text.MessageFormat;
@@ -89,6 +90,14 @@ public class CollectorFormatterTest extends AbstractLogging {
     public void testDeclaredClasses() throws Exception {
         Class<?>[] declared = CollectorFormatter.class.getDeclaredClasses();
         assertEquals(Arrays.toString(declared), 0, declared.length);
+    }
+
+    @Test
+    public void testNewInstance() throws Exception {
+        Class<?> k = CollectorFormatter.class;
+        assertTrue(Modifier.isPublic(k.getConstructor().getModifiers()));
+        Object f = LogManagerProperties.newFormatter(k.getName());
+        assertEquals(f.getClass(), k);
     }
 
     @Test

--- a/mail/src/test/java/com/sun/mail/util/logging/CollectorFormatterTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/CollectorFormatterTest.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.text.DateFormat;
 import java.text.MessageFormat;
@@ -512,7 +511,11 @@ public class CollectorFormatterTest extends AbstractLogging {
         f.format(r);
 
         String result = f.getTail((Handler) null);
-        //MessageFormat allow long values as date and time.
+        
+        //MessageFormat allows Number or Date instances as date and time.
+        //Top level MessageFormat doc show that implementaiton is DateFormat
+        //See DateFormat::format(Object,StringBuffer,FieldPosition)
+        //This must format as Number to match CollectorFormatter.
         assertEquals(result,
                 MessageFormat.format("{0,date,short} {0,time}", min));
     }
@@ -562,7 +565,13 @@ public class CollectorFormatterTest extends AbstractLogging {
         f.format(r);
 
         String result = f.getTail((Handler) null);
-        assertEquals(result, MessageFormat.format("{0,date,short} {0,time}", min + high));
+        
+        //MessageFormat allows Number or Date instances as date and time.
+        //Top level MessageFormat doc show that implementaiton is DateFormat
+        //See DateFormat::format(Object,StringBuffer,FieldPosition)
+        //This must format as Number to match CollectorFormatter.
+        assertEquals(result, MessageFormat.format("{0,date,short} {0,time}", 
+                min + high));
     }
 
     @Test

--- a/mail/src/test/java/com/sun/mail/util/logging/CompactFormatterTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/CompactFormatterTest.java
@@ -27,6 +27,7 @@ import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeUtility;
+import java.lang.reflect.Modifier;
 import org.junit.*;
 import static org.junit.Assert.*;
 
@@ -101,6 +102,14 @@ public class CompactFormatterTest extends AbstractLogging {
     @Test
     public void testDeclaredClasses() throws Exception {
         testLoadDeclaredClasses(CompactFormatter.class);
+    }
+
+    @Test
+    public void testNewInstance() throws Exception {
+        Class<?> k = CompactFormatter.class;
+        assertTrue(Modifier.isPublic(k.getConstructor().getModifiers()));
+        Object f = LogManagerProperties.newFormatter(k.getName());
+        assertEquals(f.getClass(), k);
     }
 
     @Test

--- a/mail/src/test/java/com/sun/mail/util/logging/CompactFormatterTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/CompactFormatterTest.java
@@ -27,7 +27,9 @@ import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeUtility;
-import java.lang.reflect.Modifier;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
 import org.junit.*;
 import static org.junit.Assert.*;
 
@@ -106,10 +108,30 @@ public class CompactFormatterTest extends AbstractLogging {
 
     @Test
     public void testNewInstance() throws Exception {
-        Class<?> k = CompactFormatter.class;
-        assertTrue(Modifier.isPublic(k.getConstructor().getModifiers()));
-        Object f = LogManagerProperties.newFormatter(k.getName());
-        assertEquals(f.getClass(), k);
+        final String loggerName = CompactFormatterTest.class.getName();
+        final Class<?> k = CompactFormatter.class;
+        assertNotNull(LogManagerProperties.newFormatter(k.getName()));
+
+        Logger l;
+        LogManager m = LogManager.getLogManager();
+        try {
+            Properties props = new Properties();
+            String p = ConsoleHandler.class.getName();
+            props.put(loggerName.concat(".handlers"), p);
+            props.put(p.concat(".formatter"), k.getName());
+            read(m, props);
+
+            l = Logger.getLogger(loggerName);
+            final Handler[] handlers = l.getHandlers();
+            assertEquals(1, handlers.length);
+            for (Handler h : handlers) {
+                assertEquals(p, h.getClass().getName());
+                assertEquals(k, h.getFormatter().getClass());
+            }
+        } finally {
+            m.reset();
+        }
+        assertNotNull(l); //Enusre handler is closed by reset
     }
 
     @Test

--- a/mail/src/test/java/com/sun/mail/util/logging/DurationFilterTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/DurationFilterTest.java
@@ -17,7 +17,6 @@
 package com.sun.mail.util.logging;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Properties;
@@ -61,10 +60,30 @@ public class DurationFilterTest extends AbstractLogging {
 
     @Test
     public void testNewInstance() throws Exception {
-        Class<?> k = DurationFilter.class;
-        assertTrue(Modifier.isPublic(k.getConstructor().getModifiers()));
-        Filter f = LogManagerProperties.newFilter(k.getName());
-        assertEquals(f.getClass(), k);
+        final String loggerName = DurationFilterTest.class.getName();
+        final Class<?> k = DurationFilter.class;
+        assertNotNull(LogManagerProperties.newFilter(k.getName()));
+
+        Logger l;
+        LogManager m = LogManager.getLogManager();
+        try {
+            Properties props = new Properties();
+            String p = ConsoleHandler.class.getName();
+            props.put(loggerName.concat(".handlers"), p);
+            props.put(p.concat(".filter"), k.getName());
+            read(m, props);
+
+            l = Logger.getLogger(loggerName);
+            final Handler[] handlers = l.getHandlers();
+            assertEquals(1, handlers.length);
+            for (Handler h : handlers) {
+                assertEquals(p, h.getClass().getName());
+                assertEquals(k, h.getFilter().getClass());
+            }
+        } finally {
+            m.reset();
+        }
+        assertNotNull(l); //Enusre handler is closed by reset
     }
 
     @Test

--- a/mail/src/test/java/com/sun/mail/util/logging/DurationFilterTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/DurationFilterTest.java
@@ -17,6 +17,7 @@
 package com.sun.mail.util.logging;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Properties;
@@ -56,6 +57,14 @@ public class DurationFilterTest extends AbstractLogging {
     public void testDeclaredClasses() throws Exception {
         Class<?>[] declared = DurationFilter.class.getDeclaredClasses();
         assertEquals(Arrays.toString(declared), 0, declared.length);
+    }
+
+    @Test
+    public void testNewInstance() throws Exception {
+        Class<?> k = DurationFilter.class;
+        assertTrue(Modifier.isPublic(k.getConstructor().getModifiers()));
+        Filter f = LogManagerProperties.newFilter(k.getName());
+        assertEquals(f.getClass(), k);
     }
 
     @Test

--- a/mail/src/test/java/com/sun/mail/util/logging/LogManagerPropertiesTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/LogManagerPropertiesTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2009, 2018 Jason Mehrens. All rights reserved.
+ * Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021 Jason Mehrens. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -244,6 +244,16 @@ public class LogManagerPropertiesTest extends AbstractLogging {
         } finally {
             mod.setInt(f, f.getModifiers() | Modifier.FINAL);
             fullFence();
+        }
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        Class<?> k = LogManagerProperties.class;
+        assertFalse(Modifier.isPublic(k.getModifiers()));
+        assertTrue(Modifier.isFinal(k.getModifiers()));
+        for (Constructor<?> c : k.getDeclaredConstructors()) {
+            assertFalse(Modifier.isPublic(c.getModifiers()));
         }
     }
 

--- a/mail/src/test/java/com/sun/mail/util/logging/MailHandlerTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/MailHandlerTest.java
@@ -546,6 +546,15 @@ public class MailHandlerTest extends AbstractLogging {
     }
 
     @Test
+    public void testNewInstance() throws Exception {
+        assertTrue(Modifier.isPublic(
+                MailHandler.class.getConstructor().getModifiers()));
+        Handler h = LogManagerProperties.newObjectFrom(
+                MailHandler.class.getName(), MailHandler.class);
+        h.close();
+    }
+
+    @Test
     public void testEquals() {
     	MailHandler h = new MailHandler();
     	assertFalse(h.equals((Object) null));

--- a/mail/src/test/java/com/sun/mail/util/logging/MailHandlerTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/MailHandlerTest.java
@@ -547,11 +547,28 @@ public class MailHandlerTest extends AbstractLogging {
 
     @Test
     public void testNewInstance() throws Exception {
-        assertTrue(Modifier.isPublic(
-                MailHandler.class.getConstructor().getModifiers()));
-        Handler h = LogManagerProperties.newObjectFrom(
-                MailHandler.class.getName(), MailHandler.class);
-        h.close();
+        final String loggerName = MailHandlerTest.class.getName();
+        final Class<?> k = MailHandler.class;
+        assertNotNull(LogManagerProperties.newObjectFrom(k.getName(), k));
+
+        Logger l;
+        LogManager m = LogManager.getLogManager();
+        try {
+            Properties props = new Properties();
+            String p = k.getName();
+            props.put(loggerName.concat(".handlers"), p);
+            read(m, props);
+
+            l = Logger.getLogger(loggerName);
+            final Handler[] handlers = l.getHandlers();
+            assertEquals(1, handlers.length);
+            for (Handler h : handlers) {
+                assertEquals(p, h.getClass().getName());
+            }
+        } finally {
+            m.reset();
+        }
+        assertNotNull(l); //Enusre handler is closed by reset
     }
 
     @Test

--- a/mail/src/test/java/com/sun/mail/util/logging/SeverityComparatorTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/SeverityComparatorTest.java
@@ -18,6 +18,7 @@ package com.sun.mail.util.logging;
 
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.FileLockInterruptionException;
@@ -263,12 +264,36 @@ public class SeverityComparatorTest extends AbstractLogging {
         return head;
     }
 
+    private void testInstance(Comparator<?> a) {
+        SeverityComparator b = SeverityComparator.getInstance();
+        assertNotSame(a, b);
+        assertEquals(a, b);
+        assertEquals(a.getClass(), b.getClass());
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
     @Test
-    public void testGetInstance() {
+    public void testDefaultConstructorPublic() {
+        testInstance(new SeverityComparator());
+    }
+
+    @Test
+    public void testNewInstance() throws Exception {
+        assertTrue(Modifier.isPublic(
+                SeverityComparator.class.getConstructor().getModifiers()));
+        testInstance(LogManagerProperties.newComparator(
+                SeverityComparator.class.getName()));
+    }
+
+    @Test
+    public void testReadResolve() {
+        //readResolve is not implemented encase the comparator is locked.
+        //This could be relaxed if needed.
         SeverityComparator a = new SeverityComparator();
-        assertEquals(a, SeverityComparator.getInstance());
-        assertEquals(a.getClass(), SeverityComparator.getInstance().getClass());
-        assertEquals(a.hashCode(), SeverityComparator.getInstance().hashCode());
+        SeverityComparator b = serialClone(a);
+        assertNotSame(a, b);
+        testInstance(b);
+        testInstance(serialClone(SeverityComparator.getInstance()));
     }
 
     @Test
@@ -751,15 +776,7 @@ public class SeverityComparatorTest extends AbstractLogging {
                 Throwable next = type.getConstructor().newInstance();
                 return next.initCause(cause);
             }
-        } catch (InstantiationException ex) {
-            throw new AssertionError(ex);
-        } catch (IllegalAccessException ex) {
-            throw new AssertionError(ex);
-        } catch (IllegalArgumentException ex) {
-            throw new AssertionError(ex);
-        } catch (InvocationTargetException ex) {
-            throw new AssertionError(ex);
-        } catch (NoSuchMethodException ex) {
+        } catch (ReflectiveOperationException | IllegalArgumentException ex) {
             throw new AssertionError(ex);
         }
     }
@@ -1210,25 +1227,17 @@ public class SeverityComparatorTest extends AbstractLogging {
     private <T> T serialClone(T t) {
         try {
             final ByteArrayOutputStream os = new ByteArrayOutputStream();
-            final ObjectOutputStream out = new ObjectOutputStream(os);
-            try {
+            try (ObjectOutputStream out = new ObjectOutputStream(os)) {
                 out.writeObject(t);
                 out.flush();
-            } finally {
-                out.close();
             }
 
             ByteArrayInputStream is = new ByteArrayInputStream(os.toByteArray());
-            final ObjectInputStream in = new ObjectInputStream(is);
-            try {
+            try (ObjectInputStream in = new ObjectInputStream(is)) {
                 return (T) in.readObject();
-            } finally {
-                in.close();
             }
-        } catch (ClassNotFoundException CNFE) {
+        } catch (ClassNotFoundException | IOException CNFE) {
             throw new AssertionError(CNFE);
-        } catch (IOException ioe) {
-            throw new AssertionError(ioe);
         }
     }
 

--- a/mail/src/test/java/com/sun/mail/util/logging/SeverityComparatorTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/SeverityComparatorTest.java
@@ -278,15 +278,13 @@ public class SeverityComparatorTest extends AbstractLogging {
 
     @Test
     public void testNewInstance() throws Exception {
-        assertTrue(Modifier.isPublic(
-                SeverityComparator.class.getConstructor().getModifiers()));
         testInstance(LogManagerProperties.newComparator(
                 SeverityComparator.class.getName()));
     }
 
     @Test
     public void testReadResolve() {
-        //readResolve is not implemented encase the comparator is locked.
+        //readResolve is not implemented in case the comparator is locked.
         //This could be relaxed if needed.
         SeverityComparator a = new SeverityComparator();
         SeverityComparator b = serialClone(a);

--- a/mail/src/test/java/com/sun/mail/util/logging/SeverityComparatorTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/SeverityComparatorTest.java
@@ -18,7 +18,6 @@ package com.sun.mail.util.logging;
 
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.FileLockInterruptionException;

--- a/mbox/src/main/java/com/sun/mail/mbox/Mailbox.java
+++ b/mbox/src/main/java/com/sun/mail/mbox/Mailbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,13 @@
 package com.sun.mail.mbox;
 
 public abstract class Mailbox {
+
+    /**
+     * Creates a default {@code Mailbox}.
+     */
+    public Mailbox() {
+    }
+
     /**
      * Return a MailFile object for the specified user's folder.
      */

--- a/mbox/src/main/java/com/sun/mail/mbox/SolarisMailbox.java
+++ b/mbox/src/main/java/com/sun/mail/mbox/SolarisMailbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,11 @@ public class SolarisMailbox extends Mailbox {
     private static final boolean homeRelative =
 				Boolean.getBoolean("mail.mbox.homerelative");
 
+    /**
+     * Creates a default {@code SolarisMailbox}.
+     *
+     * @throws SecurityException if unable to read the user home or user name.
+     */
     public SolarisMailbox() {
 	String h = System.getenv("HOME");
 	if (h == null)

--- a/mbox/src/main/java/com/sun/mail/mbox/SunOSMailbox.java
+++ b/mbox/src/main/java/com/sun/mail/mbox/SunOSMailbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,4 +17,12 @@
 package com.sun.mail.mbox;
 
 public class SunOSMailbox extends SolarisMailbox {
+
+    /**
+     * Creates a default {@code SunOSMailbox}.
+     *
+     * @throws SecurityException if unable to read the user home or user name.
+     */
+    public SunOSMailbox() {
+    }
 }


### PR DESCRIPTION
Fix for https://github.com/eclipse-ee4j/mail/issues/530

ComparisonTerm seem like it should have a private default or deprecated default and a new single argument constructor added.  For now I just left it as is for compatibility.  Seems like it could still use some more javadoc.

BASE64MailboxDecoder should have a private default constructor but for compatibility I included a default and deprecated it.

I added reflection tests to logging package to ensure the class and constructor modifiers are enforced.