### PR TITLE
CompactFormatter support for LogRecord::getLongThreadID #529

### DIFF
--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -19,7 +19,6 @@ Bug IDs that start with "G" can be found in the GlassFish Issue Tracker
 Seven digit bug numbers are from the old Sun bug database, which is no
 longer available.
 
-
 		  CHANGES IN THE 1.6.7 RELEASE
 		  ----------------------------
 The following bugs have been fixed in the 1.6.7 release.
@@ -41,6 +40,12 @@ E  489	mime handling crashes on Android 11 debug build
 E  493	javamail.providers file missing from provider jars after 1.6.5
 E  505	WriteTimeoutSocket::getFileDescriptor$ support for Conscrypt
 E  512	Improve code coverage in logging-mailhandler tests
+
+
+		  CHANGES IN THE 2.0.0 RELEASE
+		  ----------------------------
+The most important change here is the switch from javax to jakarta namespace.
+No bugs have been fixed in the 2.0.0 release.
 
 
 		  CHANGES IN THE 1.6.5 RELEASE

--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -19,6 +19,7 @@ Bug IDs that start with "G" can be found in the GlassFish Issue Tracker
 Seven digit bug numbers are from the old Sun bug database, which is no
 longer available.
 
+
 		  CHANGES IN THE 1.6.7 RELEASE
 		  ----------------------------
 The following bugs have been fixed in the 1.6.7 release.
@@ -40,12 +41,6 @@ E  489	mime handling crashes on Android 11 debug build
 E  493	javamail.providers file missing from provider jars after 1.6.5
 E  505	WriteTimeoutSocket::getFileDescriptor$ support for Conscrypt
 E  512	Improve code coverage in logging-mailhandler tests
-
-
-		  CHANGES IN THE 2.0.0 RELEASE
-		  ----------------------------
-The most important change here is the switch from javax to jakarta namespace.
-No bugs have been fixed in the 2.0.0 release.
 
 
 		  CHANGES IN THE 1.6.5 RELEASE

--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -24,6 +24,7 @@ longer available.
 		  ----------------------------
 The following bugs have been fixed in the 1.6.7 release.
 
+E  529	CompactFormatter support for LogRecord::getLongThreadID
 E  535	The final release of 1.6.6 identifies itself as 1.6.6-SNAPSHOT.
 
 

--- a/mail/src/main/java/com/sun/mail/util/logging/CompactFormatter.java
+++ b/mail/src/main/java/com/sun/mail/util/logging/CompactFormatter.java
@@ -344,6 +344,7 @@ public class CompactFormatter extends java.util.logging.Formatter {
      * @throws NullPointerException if the given record is null.
      * @since JavaMail 1.5.4
      */
+    @SuppressWarnings("deprecation") //See JDK-8245302
     public Number formatThreadID(final LogRecord record) {
         Long id = LogManagerProperties.getLongThreadID(record);
         if (id == null) {

--- a/mail/src/main/java/com/sun/mail/util/logging/CompactFormatter.java
+++ b/mail/src/main/java/com/sun/mail/util/logging/CompactFormatter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2019 Jason Mehrens. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Jason Mehrens. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -335,8 +335,9 @@ public class CompactFormatter extends java.util.logging.Formatter {
     }
 
     /**
-     * Formats the thread id property of the given log record. By default this
-     * is formatted as a {@code long} by an unsigned conversion.
+     * Formats the thread id property of the given log record.  Long thread ids
+     * are preferred if supported.  Otherwise, the integer thread id is
+     * formatted as a {@code long} by an unsigned conversion.
      *
      * @param record the record.
      * @return the formatted thread id as a number.
@@ -344,12 +345,11 @@ public class CompactFormatter extends java.util.logging.Formatter {
      * @since JavaMail 1.5.4
      */
     public Number formatThreadID(final LogRecord record) {
-        /**
-         * Thread.getID is defined as long and LogRecord.getThreadID is defined
-         * as int. Convert to unsigned as a means to better map the two types of
-         * thread identifiers.
-         */
-        return (((long) record.getThreadID()) & 0xffffffffL);
+        Long id = LogManagerProperties.getLongThreadID(record);
+        if (id == null) {
+            id = (((long) record.getThreadID()) & 0xffffffffL);
+        }
+        return id;
     }
 
     /**

--- a/mail/src/main/java/com/sun/mail/util/logging/LogManagerProperties.java
+++ b/mail/src/main/java/com/sun/mail/util/logging/LogManagerProperties.java
@@ -348,7 +348,7 @@ final class LogManagerProperties extends Properties {
      * @param record used to get the long thread id.
      * @return null if LogRecord doesn't support long thread ids.
      * @throws NullPointerException if record is null.
-     * @since JakartaMail 2.0.1
+     * @since JavaMail 1.6.7
      */
     static Long getLongThreadID(final LogRecord record) {
         if (record == null) {

--- a/mail/src/main/java/com/sun/mail/util/logging/LogManagerProperties.java
+++ b/mail/src/main/java/com/sun/mail/util/logging/LogManagerProperties.java
@@ -127,7 +127,6 @@ final class LogManagerProperties extends Properties {
                 lrgi = null;
                 zisd = null;
                 zdtoi = null;
-                zdtoi = null;
             }
         }
 

--- a/mail/src/main/java/com/sun/mail/util/logging/LogManagerProperties.java
+++ b/mail/src/main/java/com/sun/mail/util/logging/LogManagerProperties.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2009, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2009, 2019 Jason Mehrens. All rights reserved.
+ * Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021 Jason Mehrens. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,10 @@
 package com.sun.mail.util.logging;
 
 import java.io.*;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -55,55 +59,74 @@ final class LogManagerProperties extends Properties {
      * Generated serial id.
      */
     private static final long serialVersionUID = -2239983349056806252L;
+
+    /**
+     * Public lookup for method handles.
+     */
+    private static final Lookup LOOKUP = MethodHandles.publicLookup();
+
     /**
      * Holds the method used to get the LogRecord instant if running on JDK 9 or
      * later.
      */
-    private static final Method LR_GET_INSTANT;
+    private static final MethodHandle LR_GET_INSTANT;
+
+    /**
+     * Holds the method used to get the long thread id if running on JDK 16 or
+     * later.
+     */
+    private static final MethodHandle LR_GET_LONG_TID;
 
     /**
      * Holds the method used to get the default time zone if running on JDK 9 or
      * later.
      */
-    private static final Method ZI_SYSTEM_DEFAULT;
+    private static final MethodHandle ZI_SYSTEM_DEFAULT;
 
     /**
      * Holds the method used to convert and instant to a zoned date time if
      * running on JDK 9 later.
      */
-    private static final Method ZDT_OF_INSTANT;
+    private static final MethodHandle ZDT_OF_INSTANT;
 
-    static {
-        Method lrgi = null;
-        Method zisd = null;
-        Method zdtoi = null;
+
+    static { //Added in JDK16 see JDK-8245302
+        MethodHandle lrgltid = null;
         try {
-            lrgi = LogRecord.class.getMethod("getInstant");
-            assert Comparable.class
-                    .isAssignableFrom(lrgi.getReturnType()) : lrgi;
-            zisd = findClass("java.time.ZoneId")
-                    .getMethod("systemDefault");
-            if (!Modifier.isStatic(zisd.getModifiers())) {
-                throw new NoSuchMethodException(zisd.toString());
-            }
+            lrgltid = LOOKUP.findVirtual(LogRecord.class,
+                    "getLongThreadID", MethodType.methodType(long.class));
+        } catch (final RuntimeException ignore) {
+        } catch (final Exception ignore) { //No need for specific catch.
+        } catch (final LinkageError ignore) {
+        }
+        LR_GET_LONG_TID = lrgltid;
+    }
 
-            zdtoi = findClass("java.time.ZonedDateTime")
-                    .getMethod("ofInstant", findClass("java.time.Instant"),
-                            findClass("java.time.ZoneId"));
-            if (!Modifier.isStatic(zdtoi.getModifiers())) {
-                throw new NoSuchMethodException(zdtoi.toString());
-            }
+    static { //Added in JDK 9 see JDK-8072645
+        MethodHandle lrgi = null;
+        MethodHandle zisd = null;
+        MethodHandle zdtoi = null;
+        try {
+            lrgi = LOOKUP.findVirtual(LogRecord.class, "getInstant",
+                    MethodType.methodType(findClass("java.time.Instant")));
 
-            if (!Comparable.class.isAssignableFrom(zdtoi.getReturnType())) {
-                throw new NoSuchMethodException(zdtoi.toString());
-            }
+            zisd = LOOKUP.findStatic(findClass("java.time.ZoneId"),
+                    "systemDefault",
+                    MethodType.methodType(findClass("java.time.ZoneId")));
+
+            zdtoi = LOOKUP.findStatic(findClass("java.time.ZonedDateTime"),
+                    "ofInstant",
+                    MethodType.methodType(findClass("java.time.ZonedDateTime"),
+                            findClass("java.time.Instant"),
+                            findClass("java.time.ZoneId")));
         } catch (final RuntimeException ignore) {
         } catch (final Exception ignore) { //No need for specific catch.
         } catch (final LinkageError ignore) {
         } finally {
             if (lrgi == null || zisd == null || zdtoi == null) {
-                lrgi = null; //If any are null then clear all.
+                lrgi = null;
                 zisd = null;
+                zdtoi = null;
                 zdtoi = null;
             }
         }
@@ -112,6 +135,7 @@ final class LogManagerProperties extends Properties {
         ZI_SYSTEM_DEFAULT = zisd;
         ZDT_OF_INSTANT = zdtoi;
     }
+
     /**
      * Caches the read only reflection class names string array. Declared
      * volatile for safe publishing only. The VO_VOLATILE_REFERENCE_TO_ARRAY
@@ -299,30 +323,47 @@ final class LogManagerProperties extends Properties {
      * @throws NullPointerException if record is null.
      * @since JavaMail 1.5.6
      */
-    @SuppressWarnings("UseSpecificCatch")
-    static Comparable<?> getZonedDateTime(LogRecord record) {
+    static Comparable<?> getZonedDateTime(final LogRecord record) {
         if (record == null) {
            throw new NullPointerException();
         }
-        final Method m = ZDT_OF_INSTANT;
+
+        MethodHandle m = ZDT_OF_INSTANT;
         if (m != null) {
             try {
-                return (Comparable<?>) m.invoke((Object) null,
+                return (Comparable<?>) m.invoke(
                         LR_GET_INSTANT.invoke(record),
-                        ZI_SYSTEM_DEFAULT.invoke((Object) null));
-            } catch (final RuntimeException ignore) {
-                assert LR_GET_INSTANT != null
-                        && ZI_SYSTEM_DEFAULT != null : ignore;
-            } catch (final InvocationTargetException ite) {
-                final Throwable cause = ite.getCause();
-                if (cause instanceof Error) {
-                    throw (Error) cause;
-                } else if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                } else { //Should never happen.
-                    throw new UndeclaredThrowableException(ite);
-                }
-            } catch (final Exception ignore) {
+                        ZI_SYSTEM_DEFAULT.invoke());
+            } catch (final RuntimeException | Error e) {
+                throw e; //Avoid catch all
+            } catch (final Throwable ute) {
+                throw new UndeclaredThrowableException(ute);
+            }        
+        }
+        return null;
+    }
+
+    /**
+     * Gets the long thread id from the given log record.
+     *
+     * @param record used to get the long thread id.
+     * @return null if LogRecord doesn't support long thread ids.
+     * @throws NullPointerException if record is null.
+     * @since JakartaMail 2.0.1
+     */
+    static Long getLongThreadID(final LogRecord record) {
+        if (record == null) {
+           throw new NullPointerException();
+        }
+
+        final MethodHandle m = LR_GET_LONG_TID;
+        if (m != null) {
+            try {
+                return (long) m.invoke(record);
+            } catch (final RuntimeException | Error e) {
+                throw e;
+            } catch (final Throwable ute) {
+                throw new UndeclaredThrowableException(ute);
             }
         }
         return null;
@@ -367,7 +408,7 @@ final class LogManagerProperties extends Properties {
      * @return the number of milliseconds parsed from the duration.
      * @throws ClassNotFoundException if the java.time classes are not present.
      * @throws IllegalAccessException if the method is inaccessible.
-     * @throws InvocationTargetException if the method throws an exception.
+     * @throws RuntimeException if the method throws an exception.
      * @throws LinkageError if the linkage fails.
      * @throws NullPointerException if the given duration is null.
      * @throws ExceptionInInitializerError if the static initializer fails.
@@ -378,24 +419,23 @@ final class LogManagerProperties extends Properties {
      * @since JavaMail 1.5.5
      */
     static long parseDurationToMillis(final CharSequence value) throws Exception {
-        try {
-            final Class<?> k = findClass("java.time.Duration");
-            final Method parse = k.getMethod("parse", CharSequence.class);
-            if (!k.isAssignableFrom(parse.getReturnType())
-                    || !Modifier.isStatic(parse.getModifiers())) {
-               throw new NoSuchMethodException(parse.toString());
-            }
+        if (value == null) {
+           throw new NullPointerException();
+        }
 
-            final Method toMillis = k.getMethod("toMillis");
-            if (!Long.TYPE.isAssignableFrom(toMillis.getReturnType())
-                    || Modifier.isStatic(toMillis.getModifiers())) {
-                throw new NoSuchMethodException(toMillis.toString());
-            }
-            return (Long) toMillis.invoke(parse.invoke(null, value));
-        } catch (final ExceptionInInitializerError EIIE) {
-            throw wrapOrThrow(EIIE);
-        } catch (final InvocationTargetException ite) {
-            throw paramOrError(ite);
+        try {
+            Class<?> k = findClass("java.time.Duration");
+            MethodHandle dp = LOOKUP.findStatic(k, "parse",
+                    MethodType.methodType(k, CharSequence.class));
+
+            MethodHandle dtm = LOOKUP.findVirtual(k, "toMillis",
+                    MethodType.methodType(Long.TYPE));
+            return (long) dtm.invoke(dp.invoke(value));
+        } catch (final RuntimeException | LinkageError
+                | ReflectiveOperationException fail) {
+            throw fail; //avoid catch all
+        } catch (Throwable cause) {
+            throw new InvocationTargetException(cause);
         }
     }
 
@@ -517,9 +557,9 @@ final class LogManagerProperties extends Properties {
         }
 
         Comparator<T> reverse = null;
-        //Comparator in Java 1.8 has 'reversed' as a default method.
+        //Comparator in JDK8 has 'reversed' as a default method.
         //This code calls that method first to allow custom
-        //code to define what reverse order means.
+        //code to define what reverse order means in versions older than JDK8.
         try {
             //assert Modifier.isPublic(c.getClass().getModifiers()) :
             //        Modifier.toString(c.getClass().getModifiers());
@@ -532,11 +572,9 @@ final class LogManagerProperties extends Properties {
                     throw wrapOrThrow(eiie);
                 }
             }
-        } catch (final NoSuchMethodException ignore) {
-        } catch (final IllegalAccessException ignore) {
-        } catch (final RuntimeException ignore) {
         } catch (final InvocationTargetException ite) {
             paramOrError(ite); //Ignore invocation bugs (returned values).
+        } catch (final ReflectiveOperationException | RuntimeException ignore) {
         }
 
         if (reverse == null) {
@@ -642,6 +680,8 @@ final class LogManagerProperties extends Properties {
         final Class<?> thisClass = LogManagerProperties.class;
         assert Modifier.isFinal(thisClass.getModifiers()) : thisClass;
         try {
+            //This code must use reflection to capture extra frames.
+            //The invoke API doesn't produce the frames needed.
             final HashSet<String> traces = new HashSet<>();
             Throwable t = Throwable.class.getConstructor().newInstance();
             for (StackTraceElement ste : t.getStackTrace()) {
@@ -652,6 +692,8 @@ final class LogManagerProperties extends Properties {
                 }
             }
 
+            //This code must use reflection to capture extra frames.
+            //The invoke API doesn't produce the frames needed.
             Throwable.class.getMethod("fillInStackTrace").invoke(t);
             for (StackTraceElement ste : t.getStackTrace()) {
                 if (!thisClass.getName().equals(ste.getClassName())) {
@@ -756,10 +798,10 @@ final class LogManagerProperties extends Properties {
     }
 
     /**
-     * This code is modified from the LogManager, which explictly states
+     * This code is modified from the LogManager, which explicitly states
      * searching the system class loader first, then the context class loader.
      * There is resistance (compatibility) to change this behavior to simply
-     * searching the context class loader.
+     * searching the context class loader. See JDK-6878454.
      *
      * @param name full class name
      * @return the class.

--- a/mail/src/test/java/com/sun/mail/util/logging/AbstractLogging.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/AbstractLogging.java
@@ -178,7 +178,8 @@ abstract class AbstractLogging {
         if (record == null) {
             throw new NullPointerException();
         }
-        LogRecord.class.getMethod("setLongThreadID").invoke(record);
+        LogRecord.class.getMethod("setLongThreadID", Long.TYPE)
+                .invoke(record, id);
     }
 
     /**

--- a/mail/src/test/java/com/sun/mail/util/logging/AbstractLogging.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/AbstractLogging.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2018 Jason Mehrens. All rights reserved.
+ * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021 Jason Mehrens. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,6 +14,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
+
 package com.sun.mail.util.logging;
 
 import java.io.ByteArrayInputStream;
@@ -137,6 +138,47 @@ abstract class AbstractLogging {
         Method instant = k.getMethod("ofEpochSecond", long.class, long.class);
         Method set = LogRecord.class.getMethod("setInstant", k);
         set.invoke(record, instant.invoke(null, epochSecond, nanoAdjustment));
+    }
+
+    /**
+     * Sets the int thread id for the given log record.
+     *
+     * @param record a non null log record.
+     * @param id the thread id.
+     * @throws NullPointerException if the given record is null.
+     */
+    @SuppressWarnings("deprecation") //See JDK-8245302
+    static void setIntThreadID(final LogRecord record, int id) {
+        record.setThreadID(id);
+    }
+
+    /**
+     * Gets the int thread id for the given log record.
+     *
+     * @param record a non null log record.
+     * @param id the thread id.
+     * @throws NullPointerException if the given record is null.
+     */
+    @SuppressWarnings("deprecation") //See JDK-8245302
+    static int getIntThreadID(final LogRecord record) {
+        return record.getThreadID();
+    }
+
+    /**
+     * Sets the long thread id for the given log record if it is supported.
+     *
+     * @param record a non-null record.
+     * @param id the long thread id.
+     * @throws Exception if there is a problem.
+     * @throws NoSuchMethodException if JDK is older than JDK 16.
+     * @throws NullPointerException if the given record is null.
+     */
+    static void setLongThreadID(final LogRecord record, long id)
+                                                        throws Exception {
+        if (record == null) {
+            throw new NullPointerException();
+        }
+        LogRecord.class.getMethod("setLongThreadID").invoke(record);
     }
 
     /**

--- a/mail/src/test/java/com/sun/mail/util/logging/DurationFilterTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/DurationFilterTest.java
@@ -626,6 +626,11 @@ public class DurationFilterTest extends AbstractLogging {
     }
 
     @Test
+    public void testInitDurationLiteralNull() throws Exception {
+        testInitDuration("null", 15L * 60L * 1000L);
+    }
+
+    @Test
     public void testInitDurationZero() throws Exception {
         testInitDuration("0", 15L * 60L * 1000L);
     }
@@ -651,6 +656,8 @@ public class DurationFilterTest extends AbstractLogging {
         testInitDuration("15 *", 15L * 60L * 1000L);
         testInitDuration(" * 15", 15L * 60L * 1000L);
         testInitDuration("15 * ", 15L * 60L * 1000L);
+        testInitDuration("*", 15L * 60L * 1000L);
+        testInitDuration(" * ", 15L * 60L * 1000L);
     }
 
     @Test
@@ -751,6 +758,21 @@ public class DurationFilterTest extends AbstractLogging {
             testInitDuration("P2DT3H4M20.345S", (2L * 24L * 60L * 60L * 1000L)
                     + (3L * 60L * 60L * 1000L) + (4L * 60L * 1000L)
                     + ((20L * 1000L) + 345));
+        }
+    }
+
+    @Test
+    public void testInitDurationIso8601OverFlow() throws Exception {
+        if (hasJavaTimeModule()) {
+            testInitDuration("PT2562047788015H12M55.808S", 15L * 60L * 1000L);
+        }
+    }
+
+    @Test
+    public void testInitDurationIso8601UnderFlow() throws Exception {
+        if (hasJavaTimeModule()) {
+            testInitDuration("PT-2562047788015H-12M-55.809S",
+                    15L * 60L * 1000L);
         }
     }
 

--- a/mail/src/test/java/com/sun/mail/util/logging/LogManagerPropertiesTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/LogManagerPropertiesTest.java
@@ -1198,6 +1198,12 @@ public class LogManagerPropertiesTest extends AbstractLogging {
             assertEquals(id, (long) LogManagerProperties.getLongThreadID(r1));
             assertEquals(id, (long) LogManagerProperties.getLongThreadID(r2));
         } catch (final NoSuchMethodException preJdkSixteen) {
+            try {
+              Method m = LogRecord.class.getMethod("getLongThreadID");
+              fail(m.toString());
+            } catch (NoSuchMethodException expect) {
+                assertNull(LogManagerProperties.getLongThreadID(r1));
+            }
         }
     }
 


### PR DESCRIPTION
This is the 1.x backport of https://github.com/eclipse-ee4j/mail/issues/529