### PR TITLE
MethodHandles only supported in Android API version 26

### DIFF
--- a/mail/src/test/java/com/sun/mail/util/logging/LogManagerPropertiesTest.java
+++ b/mail/src/test/java/com/sun/mail/util/logging/LogManagerPropertiesTest.java
@@ -492,12 +492,12 @@ public class LogManagerPropertiesTest extends AbstractLogging {
             fail(Long.toString(ms));
         } catch (ClassNotFoundException | NoClassDefFoundError ignore) {
             assertFalse(ignore.toString(), hasJavaTimeModule());
-        } catch (RuntimeException expected) {
+        } catch (InvocationTargetException expected) {
+            Throwable dtpe = expected.getCause();
             //Allow subclasses of DTPE
             Class<?> k = Class.forName(
                     "java.time.format.DateTimeParseException");
-            assertTrue(expected.toString(),
-                    k.isAssignableFrom(expected.getClass()));
+            assertTrue(k.getName(), k.isAssignableFrom(dtpe.getClass()));
         }
     }
 


### PR DESCRIPTION
@lukasj Here is the patch for https://github.com/eclipse-ee4j/mail/issues/529 to fix the issue with MethodHandles on Android.  What test are you running to check for this error? Something on the build server?