### PR TITLE
StreamProvider not static and OSGi support

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -350,6 +350,10 @@
                         <Implementation-Title>${project.name}</Implementation-Title>
                         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                         <Implementation-Build-Id>${buildNumber}</Implementation-Build-Id>
+                        <Import-Package>
+                            !org.glassfish.hk2.osgiresourcelocator,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>
@@ -404,6 +408,7 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                 <configuration>
                     <forkCount>2</forkCount>
                     <reuseForks>false</reuseForks>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
             <plugin>

--- a/api/src/main/java/jakarta/mail/BodyPart.java
+++ b/api/src/main/java/jakarta/mail/BodyPart.java
@@ -16,6 +16,8 @@
 
 package jakarta.mail;
 
+import jakarta.mail.util.StreamProvider;
+
 /**
  * This class models a Part that is contained within a Multipart.
  * This is an abstract class. Subclasses provide actual implementations.<p>
@@ -35,6 +37,13 @@ public abstract class BodyPart implements Part {
      * @since	JavaMail 1.1
      */
     protected Multipart parent;
+
+    /**
+     * Instance of stream provider.
+     *
+     * @since JavaMail 2.1
+     */
+    protected final StreamProvider streamProvider = StreamProvider.provider();
 
     /**
      * Creates a default {@code BodyPart}.

--- a/api/src/main/java/jakarta/mail/Multipart.java
+++ b/api/src/main/java/jakarta/mail/Multipart.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 import jakarta.activation.DataSource;
+import jakarta.mail.util.StreamProvider;
 
 /**
  * Multipart is a container that holds multiple body parts. Multipart
@@ -59,6 +60,13 @@ public abstract class Multipart {
      * @since	JavaMail 1.1
      */
     protected Part parent;
+
+    /**
+     * Instance of stream provider.
+     *
+     * @since JavaMail 2.1
+     */
+    protected final StreamProvider streamProvider = StreamProvider.provider();
 
     /** 
      * Default constructor. An empty Multipart object is created.

--- a/api/src/main/java/jakarta/mail/internet/InternetHeaders.java
+++ b/api/src/main/java/jakarta/mail/internet/InternetHeaders.java
@@ -16,21 +16,18 @@
 
 package jakarta.mail.internet;
 
-import jakarta.mail.Header;
-import jakarta.mail.MessagingException;
-import jakarta.mail.Session;
-import jakarta.mail.util.LineInputStream;
-import jakarta.mail.util.StreamProvider;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
+
+import jakarta.mail.Header;
+import jakarta.mail.MessagingException;
+import jakarta.mail.util.LineInputStream;
+import jakarta.mail.util.StreamProvider;
 
 
 
@@ -407,7 +404,7 @@ public class InternetHeaders {
 	// Read header lines until a blank line. It is valid
 	// to have BodyParts with no header lines.
 	String line;
-	LineInputStream lis = Session.STREAM_PROVIDER.inputLineStream(is, allowutf8);
+	LineInputStream lis = StreamProvider.provider().inputLineStream(is, allowutf8);
 	String prevline = null;	// the previous header line, as a string
 	// a buffer to accumulate the header in, when we know it's needed
 	StringBuilder lineBuffer = new StringBuilder();

--- a/api/src/main/java/jakarta/mail/internet/MimeBodyPart.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeBodyPart.java
@@ -1659,7 +1659,7 @@ public class MimeBodyPart extends BodyPart implements MimePart {
 	} else {
 	    Map<String, Object> params = new HashMap<>();
 	    params.put("allowutf8", allowutf8);
-	    los = Session.STREAM_PROVIDER.outputLineStream(os, allowutf8);
+	    los = StreamProvider.provider().outputLineStream(os, allowutf8);
 	}
 
 	// First, write out the header

--- a/api/src/main/java/jakarta/mail/internet/MimeMessage.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeMessage.java
@@ -244,7 +244,7 @@ public class MimeMessage extends Message implements MimePart {
 	    strict = source.strict;
 	    source.writeTo(bos);
 	    bos.close();
-	    InputStream bis = Session.STREAM_PROVIDER.inputSharedByteArray(bos.toByteArray());
+	    InputStream bis = session.getStreamProvider().inputSharedByteArray(bos.toByteArray());
 	    parse(bis);
 	    bis.close();
 	    saved = true;
@@ -1404,7 +1404,7 @@ public class MimeMessage extends Message implements MimePart {
 	if (contentStream != null)
 	    return ((SharedInputStream)contentStream).newStream(0, -1);
 	if (content != null) {
-        return Session.STREAM_PROVIDER.inputSharedByteArray(content);
+        return session.getStreamProvider().inputSharedByteArray(content);
 	}
 	throw new MessagingException("No MimeMessage content");
     }
@@ -1911,7 +1911,7 @@ public class MimeMessage extends Message implements MimePart {
 	// Else, the content is untouched, so we can just output it
 	// First, write out the header
 	Enumeration<String> hdrLines = getNonMatchingHeaderLines(ignoreList);
-    LineOutputStream los = Session.STREAM_PROVIDER.outputLineStream(os, allowutf8);
+    LineOutputStream los = session.getStreamProvider().outputLineStream(os, allowutf8);
 	while (hdrLines.hasMoreElements())
 	    los.writeln(hdrLines.nextElement());
 

--- a/api/src/main/java/jakarta/mail/internet/MimeMultipart.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeMultipart.java
@@ -16,6 +16,14 @@
 
 package jakarta.mail.internet;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 import jakarta.activation.DataSource;
 import jakarta.mail.BodyPart;
 import jakarta.mail.IllegalWriteException;
@@ -24,19 +32,8 @@ import jakarta.mail.MessageContext;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
 import jakarta.mail.MultipartDataSource;
-import jakarta.mail.Session;
-import jakarta.mail.internet.MimeUtility;
 import jakarta.mail.util.LineInputStream;
 import jakarta.mail.util.LineOutputStream;
-import jakarta.mail.util.StreamProvider;
-
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 
 
 
@@ -524,7 +521,7 @@ public class MimeMultipart extends Multipart {
 	
 	String boundary = "--" + 
 		(new ContentType(contentType)).getParameter("boundary");
-    LineOutputStream los = Session.STREAM_PROVIDER.outputLineStream(os, false);
+    LineOutputStream los = streamProvider.outputLineStream(os, false);
 	// if there's a preamble, write it out
 	if (preamble != null) {
 	    byte[] pb = MimeUtility.getBytes(preamble);
@@ -605,7 +602,7 @@ public class MimeMultipart extends Multipart {
 
 	try {
 	    // Skip and save the preamble
-		LineInputStream lin = Session.STREAM_PROVIDER.inputLineStream(in, false);
+		LineInputStream lin = streamProvider.inputLineStream(in, false);
 	    StringBuilder preamblesb = null;
 	    String line;
 	    while ((line = lin.readLine()) != null) {

--- a/api/src/main/java/jakarta/mail/internet/MimeUtility.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeUtility.java
@@ -22,7 +22,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
@@ -38,8 +37,8 @@ import jakarta.activation.DataHandler;
 import jakarta.activation.DataSource;
 import jakarta.mail.EncodingAware;
 import jakarta.mail.MessagingException;
-import jakarta.mail.Session;
 import jakarta.mail.util.LineInputStream;
+import jakarta.mail.util.StreamProvider;
 import jakarta.mail.util.StreamProvider.EncoderTypes;
 
 /**
@@ -366,17 +365,17 @@ public class MimeUtility {
     public static InputStream decode(InputStream is, String encoding)
 		throws MessagingException {
 	if (encoding.equalsIgnoreCase(EncoderTypes.BASE_64.getEncoder()))
-		return Session.STREAM_PROVIDER.inputBase64(is);
+		return StreamProvider.provider().inputBase64(is);
 	else if (encoding.equalsIgnoreCase(EncoderTypes.QUOTED_PRINTABLE_ENCODER.getEncoder()))
-		return Session.STREAM_PROVIDER.inputQP(is);
+		return StreamProvider.provider().inputQP(is);
 	else if (encoding.equalsIgnoreCase(EncoderTypes.UU_ENCODER.getEncoder()) ||
 		 encoding.equalsIgnoreCase(EncoderTypes.X_UU_ENCODER.getEncoder()) ||
 		 encoding.equalsIgnoreCase(EncoderTypes.X_UUE.getEncoder()))
-		return Session.STREAM_PROVIDER.inputUU(is);
+		return StreamProvider.provider().inputUU(is);
 	else if (encoding.equalsIgnoreCase(EncoderTypes.BINARY_ENCODER.getEncoder()) ||
 		 encoding.equalsIgnoreCase(EncoderTypes.BIT7_ENCODER.getEncoder()) ||
 		 encoding.equalsIgnoreCase(EncoderTypes.BIT8_ENCODER.getEncoder()))
-		return Session.STREAM_PROVIDER.inputBinary(is);
+		return StreamProvider.provider().inputBinary(is);
 	else {
 	    if (!ignoreUnknownEncoding)
 		throw new MessagingException("Unknown encoding: " + encoding);
@@ -401,17 +400,17 @@ public class MimeUtility {
         if (encoding == null)
 	    return os;
 	else if (encoding.equalsIgnoreCase(EncoderTypes.BASE_64.getEncoder()))
-		return Session.STREAM_PROVIDER.outputBase64(os);
+		return StreamProvider.provider().outputBase64(os);
 	else if (encoding.equalsIgnoreCase(EncoderTypes.QUOTED_PRINTABLE_ENCODER.getEncoder()))
-        return Session.STREAM_PROVIDER.outputQP(os);
+        return StreamProvider.provider().outputQP(os);
 	else if (encoding.equalsIgnoreCase(EncoderTypes.UU_ENCODER.getEncoder()) ||
 		 encoding.equalsIgnoreCase(EncoderTypes.X_UU_ENCODER.getEncoder()) ||
 		 encoding.equalsIgnoreCase(EncoderTypes.X_UUE.getEncoder()))
-		return Session.STREAM_PROVIDER.outputUU(os, null);
+		return StreamProvider.provider().outputUU(os, null);
 	else if (encoding.equalsIgnoreCase(EncoderTypes.BINARY_ENCODER.getEncoder()) ||
 		 encoding.equalsIgnoreCase(EncoderTypes.BIT7_ENCODER.getEncoder()) ||
 		 encoding.equalsIgnoreCase(EncoderTypes.BIT8_ENCODER.getEncoder()))
-	    return Session.STREAM_PROVIDER.outputBinary(os);
+	    return StreamProvider.provider().outputBinary(os);
 	else
 	    throw new MessagingException("Unknown encoding: " +encoding);
     }
@@ -439,17 +438,17 @@ public class MimeUtility {
         if (encoding == null)
             return os;
         else if (encoding.equalsIgnoreCase(EncoderTypes.BASE_64.getEncoder()))
-        	return Session.STREAM_PROVIDER.outputBase64(os);
+        	return StreamProvider.provider().outputBase64(os);
         else if (encoding.equalsIgnoreCase(EncoderTypes.QUOTED_PRINTABLE_ENCODER.getEncoder()))
-        	return Session.STREAM_PROVIDER.outputQP(os);
+        	return StreamProvider.provider().outputQP(os);
         else if (encoding.equalsIgnoreCase(EncoderTypes.UU_ENCODER.getEncoder()) ||
                  encoding.equalsIgnoreCase(EncoderTypes.X_UU_ENCODER.getEncoder()) ||
                  encoding.equalsIgnoreCase(EncoderTypes.X_UUE.getEncoder()))
-        	return Session.STREAM_PROVIDER.outputUU(os, filename);
+        	return StreamProvider.provider().outputUU(os, filename);
         else if (encoding.equalsIgnoreCase(EncoderTypes.BINARY_ENCODER.getEncoder()) ||
                  encoding.equalsIgnoreCase(EncoderTypes.BIT7_ENCODER.getEncoder()) ||
                  encoding.equalsIgnoreCase(EncoderTypes.BIT8_ENCODER.getEncoder()))
-        	return Session.STREAM_PROVIDER.outputBinary(os);
+        	return StreamProvider.provider().outputBinary(os);
         else
             throw new MessagingException("Unknown encoding: " +encoding);
     }
@@ -822,9 +821,9 @@ public class MimeUtility {
 	    ByteArrayOutputStream os = new ByteArrayOutputStream();
 	    OutputStream eos; // the encoder
 	    if (b64) { // "B" encoding
-	        eos = Session.STREAM_PROVIDER.outputB(os);
+	        eos = StreamProvider.provider().outputB(os);
 	    } else { // "Q" encoding
-	        eos = Session.STREAM_PROVIDER.outputQ(os, encodingWord);
+	        eos = StreamProvider.provider().outputQ(os, encodingWord);
 	    }
 	    
 	    try { // do the encoding
@@ -911,9 +910,9 @@ public class MimeUtility {
 		// Get the appropriate decoder
 		InputStream is;
 		if (encoding.equalsIgnoreCase("B")) 
-		    is = Session.STREAM_PROVIDER.inputBase64(bis);
+		    is = StreamProvider.provider().inputBase64(bis);
 		else if (encoding.equalsIgnoreCase("Q"))
-		    is = Session.STREAM_PROVIDER.inputQ(bis);
+		    is = StreamProvider.provider().inputQ(bis);
 		else
 		    throw new UnsupportedEncodingException(
 				    "unknown encoding: " + encoding);
@@ -1369,7 +1368,7 @@ public class MimeUtility {
 
 	    if (is != null) {
 		try {
-			LineInputStream lineInput = Session.STREAM_PROVIDER.inputLineStream(is, false);
+			LineInputStream lineInput = StreamProvider.provider().inputLineStream(is, false);
 
 		    // Load the JDK-to-MIME charset mapping table
 		    loadMappings(lineInput, java2mime);

--- a/api/src/main/java/jakarta/mail/internet/PreencodedMimeBodyPart.java
+++ b/api/src/main/java/jakarta/mail/internet/PreencodedMimeBodyPart.java
@@ -16,14 +16,12 @@
 
 package jakarta.mail.internet;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.Session;
-import jakarta.mail.util.LineOutputStream;
-import jakarta.mail.util.StreamProvider;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Enumeration;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.util.LineOutputStream;
 
 /**
  * A MimeBodyPart that handles data that has already been encoded.
@@ -80,7 +78,7 @@ public class PreencodedMimeBodyPart extends MimeBodyPart {
 	if (os instanceof LineOutputStream) {
 	    los = (LineOutputStream) os;
 	} else {
-	    los = Session.STREAM_PROVIDER.outputLineStream(os, false);
+	    los = streamProvider.outputLineStream(os, false);
 	}
 
 	// First, write out the header

--- a/api/src/main/java/jakarta/mail/util/FactoryFinder.java
+++ b/api/src/main/java/jakarta/mail/util/FactoryFinder.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.mail.util;
+
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+class FactoryFinder {
+
+    /**
+     * Finds the implementation {@code Class} object for the given
+     * factory type.
+     * The arguments supplied must be used in order
+     * This method is package private so that this code can be shared.
+     *
+     * @return the {@code Class} object of the specified message factory
+     *
+     * @param factoryClass          factory abstract class or interface to be found
+     * @exception RuntimeException if there is an error
+     */
+    static <T> T find(Class<T> factoryClass) throws RuntimeException {
+
+        String factoryId = factoryClass.getName();
+
+        // Use the system property first
+        String className = fromSystemProperty(factoryId);
+        if (className != null) {
+            T result = newInstance(className);
+            if (result != null) {
+                return result;
+            }
+        }
+
+        // standard services: java.util.ServiceLoader
+        T factory = factoryFromServiceLoader(factoryClass);
+        if (factory != null) {
+            return factory;
+        }
+
+        // handling Glassfish/OSGi (platform specific default)
+        if (isOsgi()) {
+            T result = lookupUsingOSGiServiceLoader(factoryId);
+            if (result != null) {
+                return result;
+            }
+        }
+        throw new IllegalStateException("Not provider of " + factoryClass.getName() + " was found");
+    }
+
+    private static <T> T newInstance(String className) throws RuntimeException {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        checkPackageAccess(className);
+        Class<T> clazz = null;
+        try {
+            if (classLoader == null) {
+                clazz = (Class<T>) Class.forName(className);
+            } else {
+                clazz = (Class<T>) classLoader.loadClass(className);
+            }
+            return clazz.getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException("Cannot instance " + className, e);
+        }
+    }
+
+    private static String fromSystemProperty(String factoryId) {
+        String systemProp = getSystemProperty(factoryId);
+        return systemProp;
+    }
+
+    private static String getSystemProperty(final String property) {
+        String value = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return System.getProperty(property);
+            }
+        });
+        return value;
+    }
+
+    private static final String OSGI_SERVICE_LOADER_CLASS_NAME = "org.glassfish.hk2.osgiresourcelocator.ServiceLoader";
+
+    private static boolean isOsgi() {
+        try {
+            Class.forName(OSGI_SERVICE_LOADER_CLASS_NAME);
+            return true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        return false;
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private static <T> T lookupUsingOSGiServiceLoader(String factoryId) {
+        try {
+            // Use reflection to avoid having any dependency on HK2 ServiceLoader class
+            Class<?> serviceClass = Class.forName(factoryId);
+            Class<?>[] args = new Class<?>[]{serviceClass};
+            Class<?> target = Class.forName(OSGI_SERVICE_LOADER_CLASS_NAME);
+            Method m = target.getMethod("lookupProviderInstances", Class.class);
+            Iterator<?> iter = ((Iterable<?>) m.invoke(null, (Object[]) args)).iterator();
+            return iter.hasNext() ? (T) iter.next() : null;
+        } catch (Exception ignored) {
+            // log and continue
+            return null;
+        }
+    }
+
+    private static <T> T factoryFromServiceLoader(Class<T> factory) {
+        try {
+            ServiceLoader<T> sl = ServiceLoader.load(factory);
+            Iterator<T> iter = sl.iterator();
+            if (iter.hasNext()) {
+                return iter.next();
+            } else {
+                return null;
+            }
+        } catch (Throwable t) {
+            // For example, ServiceConfigurationError can be thrown if the factory class is not declared with 'uses' in module-info
+            throw new IllegalStateException("Cannot load " + factory + " as ServiceLoader", t);
+        }
+    }
+    
+    private static void checkPackageAccess(String className) {
+        // make sure that the current thread has an access to the package of the given name.
+        SecurityManager s = System.getSecurityManager();
+        if (s != null) {
+            int i = className.lastIndexOf('.');
+            if (i != -1) {
+                s.checkPackageAccess(className.substring(0, i));
+            }
+        }
+    }
+}
+

--- a/api/src/main/java/jakarta/mail/util/StreamProvider.java
+++ b/api/src/main/java/jakarta/mail/util/StreamProvider.java
@@ -18,6 +18,8 @@ package jakarta.mail.util;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Iterator;
+import java.util.ServiceLoader;
 
 /**
  * Service lookup is used to find implementations of this interface.
@@ -25,11 +27,14 @@ import java.io.OutputStream;
  * It contains the methods to instance different encoders/decoders and
  * other streams required by the API.
  *
+ * @since JavaMail 2.1
  */
 public interface StreamProvider {
 
 	/**
 	 * Enumeration with the different encoder types supported by the Mail API.
+	 *
+	 * @since JavaMail 2.1
 	 */
 	public static enum EncoderTypes {
 		
@@ -159,4 +164,22 @@ public interface StreamProvider {
 	 * @return the encoder
 	 */
 	OutputStream outputUU(OutputStream out, String filename);
+
+	/**
+     * Creates a stream provider object. The provider is loaded using the
+     * {@link ServiceLoader#load(Class)} method. If there are no available
+     * service providers, this method throws an IllegalStateException.
+     * Users are recommended to cache the result of this method.
+     *
+     * @return a stream provider
+     */
+    public static StreamProvider provider() {
+        ServiceLoader<StreamProvider> sl = ServiceLoader.load(StreamProvider.class);
+        Iterator<StreamProvider> iter = sl.iterator();
+        if (iter.hasNext()) {
+            return iter.next();
+        } else {
+            throw new IllegalStateException("Not provider of " + StreamProvider.class.getName() + " was found");
+        }
+    }
 }

--- a/api/src/main/java/jakarta/mail/util/StreamProvider.java
+++ b/api/src/main/java/jakarta/mail/util/StreamProvider.java
@@ -174,12 +174,6 @@ public interface StreamProvider {
      * @return a stream provider
      */
     public static StreamProvider provider() {
-        ServiceLoader<StreamProvider> sl = ServiceLoader.load(StreamProvider.class);
-        Iterator<StreamProvider> iter = sl.iterator();
-        if (iter.hasNext()) {
-            return iter.next();
-        } else {
-            throw new IllegalStateException("Not provider of " + StreamProvider.class.getName() + " was found");
-        }
+        return FactoryFinder.find(StreamProvider.class);
     }
 }

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -27,4 +27,6 @@ module jakarta.mail {
 
     uses jakarta.mail.Provider;
     uses jakarta.mail.util.StreamProvider;
+    //reflective call to java.beans.Beans.instantiate
+    requires static java.desktop;
 }

--- a/api/src/test/java/jakarta/mail/util/DummyStreamProvider.java
+++ b/api/src/test/java/jakarta/mail/util/DummyStreamProvider.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.mail.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class DummyStreamProvider implements StreamProvider {
+
+    @Override
+    public InputStream inputBase64(InputStream in) {
+        return null;
+    }
+
+    @Override
+    public OutputStream outputBase64(OutputStream out) {
+        return null;
+    }
+
+    @Override
+    public InputStream inputBinary(InputStream in) {
+        return null;
+    }
+
+    @Override
+    public OutputStream outputBinary(OutputStream out) {
+        return null;
+    }
+
+    @Override
+    public OutputStream outputB(OutputStream out) {
+        return null;
+    }
+
+    @Override
+    public InputStream inputQ(InputStream in) {
+        return null;
+    }
+
+    @Override
+    public OutputStream outputQ(OutputStream out, boolean encodingWord) {
+        return null;
+    }
+
+    @Override
+    public LineInputStream inputLineStream(InputStream in, boolean allowutf8) {
+        return new LineInputStream() {
+            @Override
+            public String readLine() throws IOException {
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public LineOutputStream outputLineStream(OutputStream out, boolean allowutf8) {
+        return null;
+    }
+
+    @Override
+    public InputStream inputQP(InputStream in) {
+        return null;
+    }
+
+    @Override
+    public OutputStream outputQP(OutputStream out) {
+        return null;
+    }
+
+    @Override
+    public InputStream inputSharedByteArray(byte[] buff) {
+        return null;
+    }
+
+    @Override
+    public InputStream inputUU(InputStream in) {
+        return null;
+    }
+
+    @Override
+    public OutputStream outputUU(OutputStream out, String filename) {
+        return null;
+    }
+
+}

--- a/api/src/test/java/jakarta/mail/util/FactoryFinderTest.java
+++ b/api/src/test/java/jakarta/mail/util/FactoryFinderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.mail.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.util.ServiceConfigurationError;
+
+import org.junit.Test;
+
+public class FactoryFinderTest {
+
+    @Test
+    public void specifiedInSystemProperty() {
+        System.setProperty(Class1.class.getName(), Class2.class.getName());
+        Class1 impl = FactoryFinder.find(Class1.class);
+        assertEquals(Class2.class, impl.getClass());
+    }
+    
+    @Test
+    public void specifiedInServiceLoader() {
+        StreamProvider impl = FactoryFinder.find(StreamProvider.class);
+        assertEquals(DummyStreamProvider.class, impl.getClass());
+    }
+    
+    @Test
+    public void doesNotExist() {
+        try {
+            FactoryFinder.find(Class2.class);
+            fail("IllegalStateException is expected");
+        } catch (IllegalStateException e) {
+            assertNull(e.getCause());
+        }
+        try {
+            FactoryFinder.find(Class3.class);
+            fail("IllegalStateException is expected");
+        } catch (IllegalStateException e) {
+            // java.util.ServiceConfigurationError: jakarta.mail.util.FactoryFinderTest$Class3: module jakarta.mail does not declare `uses`
+            assertEquals(ServiceConfigurationError.class, e.getCause().getClass());
+        }
+    }
+    
+    public static class Class1 {}
+    public static class Class2 extends Class1 {}
+    public static class Class3 {}
+}

--- a/api/src/test/java/module-info.java
+++ b/api/src/test/java/module-info.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+module jakarta.mail {
+
+    requires java.logging;
+    requires transitive jakarta.activation;
+    requires junit;
+
+    exports jakarta.mail;
+    exports jakarta.mail.event;
+    exports jakarta.mail.internet;
+    exports jakarta.mail.search;
+    exports jakarta.mail.util;
+
+    uses jakarta.mail.Provider;
+    uses jakarta.mail.util.StreamProvider;
+    provides jakarta.mail.util.StreamProvider with jakarta.mail.util.DummyStreamProvider;
+}

--- a/api/src/test/java/module-info.java
+++ b/api/src/test/java/module-info.java
@@ -28,5 +28,6 @@ module jakarta.mail {
 
     uses jakarta.mail.Provider;
     uses jakarta.mail.util.StreamProvider;
+    uses jakarta.mail.util.FactoryFinderTest.Class2;
     provides jakarta.mail.util.StreamProvider with jakarta.mail.util.DummyStreamProvider;
 }

--- a/api/src/test/resources/META-INF/services/jakarta.mail.util.StreamProvider
+++ b/api/src/test/resources/META-INF/services/jakarta.mail.util.StreamProvider
@@ -1,0 +1,1 @@
+jakarta.mail.util.DummyStreamProvider


### PR DESCRIPTION
StreamProvider is supposed to be implemented by different implementations, and it was instanced one time in a static variable.

This could be a problem in server containers, because only one instance would exist. It could happen that it is loaded as com.sun.mail, and later an application with other implementation is deployed.  In this case, this application would still use com.sun.mail.