### PR TITLE
End MIME boundary should be followed by CRLF

### DIFF
--- a/api/src/main/java/jakarta/mail/internet/MimeMultipart.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeMultipart.java
@@ -806,9 +806,25 @@ public class MimeMultipart extends Multipart {
 			    int b2 = in.read();
 			    if (b2 == '-') {
 				if (in.read() == '-') {
-				    complete = true;
-				    done = true;
-				    break;	// ignore trailing text
+					int b3 = in.read();
+					// skip linear whitespace
+					while (b3 == ' ' || b3 == '\t')
+					{ b3 = in.read(); }
+					if (b3 == '\n' || b3 == '\r')
+					{
+						if(b3 == '\r')
+						{
+							// consume '\n' if it follows, so that next read
+							// starts from first character of the epilogue.
+							// useful if in future epilogue extraction is added
+							in.mark(1);
+							if (in.read() != '\n')
+							{ in.reset(); }
+						}
+						complete = true;
+						done = true;
+						break;    // ignore trailing text
+					}
 				}
 			    }
 			    // skip linear whitespace

--- a/api/src/main/java/jakarta/mail/internet/MimeMultipart.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeMultipart.java
@@ -810,7 +810,7 @@ public class MimeMultipart extends Multipart {
 					// skip linear whitespace
 					while (b3 == ' ' || b3 == '\t')
 					{ b3 = in.read(); }
-					if (b3 == '\n' || b3 == '\r')
+					if (b3 == '\n' || b3 == '\r' || b3 == -1)
 					{
 						if(b3 == '\r')
 						{


### PR DESCRIPTION
The present code mandates that a CRLF is present after intermediate MIME boundary (that doesn't end with --). This change extends that behaviour for end boundary too (that starts and ends with --).
This is useful for processing some bulk emails that uses a single dash character as a boundary and a line full of dashes is present in the content. Gmail and Outlook are able to process such emails, however JavaMail truncates the email after the sequence of five dash characters are consumed from the line full of dash characters.

Signed-off-by : The author is aware of the terms by which the contribution has been provided to the project.