### PR TITLE
jakartaee/cts-javamail-base:0.3 for higher maven version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,4 +42,4 @@ jobs:
     - name: Verify
       run: |
         cd api
-        mvn -B -U -C -V clean verify org.glassfish.copyright:glassfish-copyright-maven-plugin:check -Poss-release,staging -Dgpg.skip=true
+        mvn -B -U -C -V clean verify org.glassfish.copyright:glassfish-copyright-maven-plugin:check -Poss-release,staging -Dcopyright.ignoreyear=true -Dgpg.skip=true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ spec:
     - "james.local"
   containers:
   - name: mail-ci
-    image: jakartaee/cts-javamail-base:0.1
+    image: jakartaee/cts-javamail-base:0.3
     command:
     - cat
     tty: true


### PR DESCRIPTION
This PR is related to this other https://github.com/eclipse-ee4j/mail/pull/601

But it looks Jenkinsfile is obtained from master, so I cannot make progress in the other PR till this is merged.

This change should fix this issue:
`Detected Maven Version: 3.5.4 is not in the allowed range [3.6.3,).`

https://hub.docker.com/layers/cts-javamail-base/jakartaee/cts-javamail-base/0.3/images/sha256-fc4cc01c05672047a40292a3dcb46452c6f422517b2933e64f21a25eee0d3ee3?context=explore