### PR TITLE
Fix wrong jar path file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,8 +71,8 @@ spec:
             cd ..
             bash -x ${WORKSPACE}/docker/build_jakartamail.sh
           """
-          archiveArtifacts artifacts: 'mail/target/*.jar'
-          stash includes: 'mail/target/*.jar', name: 'mail-bundles'
+          archiveArtifacts artifacts: '**/target/*.jar'
+          stash includes: '**/target/*.jar', name: 'mail-bundles'
         }
       }
     }


### PR DESCRIPTION
There are still some errors in Jenkinsfile

```
[](https://ci.eclipse.org/mail/job/mail/job/PR-601/4/console#)[](https://ci.eclipse.org/mail/job/mail/job/PR-601/4/console#)[](https://ci.eclipse.org/mail/job/mail/job/PR-601/4/console#)[Pipeline] archiveArtifacts
Archiving artifacts
‘mail/target/*.jar’ doesn’t match anything: even ‘mail’ doesn’t exist
[Pipeline] }
[Pipeline] // container
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (mail-tck-run)
Stage "mail-tck-run" skipped due to earlier failure(s)
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // podTemplate
[Pipeline] End of Pipeline
ERROR: No artifacts found that match the file pattern "mail/target/*.jar". Configuration error?
```