### PR TITLE
Fix version in CHANGES.txt

### DIFF
--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -19,12 +19,9 @@ Bug IDs that start with "G" can be found in the GlassFish Issue Tracker
 Seven digit bug numbers are from the old Sun bug database, which is no
 longer available.
 
-      CHANGES IN THE 2.1.5 RELEASE
-      ----------------------------
-E  777 services/jakarta.mail.Provider override not working
-
       CHANGES IN THE 2.1.4 RELEASE
       ----------------------------
+E  777 services/jakarta.mail.Provider override not working
 E  699 Multipart performs blocking call in every instantiation
 E  527 Using Jakarta mail and Javamail in the same runtime
 


### PR DESCRIPTION
I added wrongly next line in version 2.1.5:

`E  777 services/jakarta.mail.Provider override not working`